### PR TITLE
DAP debugger + Razor highlighting + formatter chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Razor / `.cshtml` syntax highlighting.** New `Lang::Razor` variant
+  routed via `tree-sitter-razor`, paired with the bundled C# highlights
+  query plus a Razor overlay that tags every `@`-marker directive
+  (`@inject`, `@using`, `@{`, `@if`, `@(expr)`, `@Identifier`, `@*…*@`,
+  …) as `@keyword.directive` and HTML element delimiters as
+  `@punctuation.bracket`. Tag names and attribute names — anonymous
+  lexer rules in the grammar — get coloured by a byte-level overlay so
+  they still light up when the grammar's parser produces ERROR nodes
+  (typical for Tailwind `class="…[16px]…"` attribute values, BOM
+  headers, etc.). C# keywords inside broken regions get a regex-based
+  fallback paint so an `else { if (x) {…} }` block keeps its colour
+  even when the tree-sitter pass can't reach the tokens.
+- **`<leader>f` formats the active buffer.** Same path as `:fmt` /
+  `:format`. Picks the right tool per extension:
+- **csharpier integration for `.cs` (and `.cshtml` / `.razor` once a
+  future csharpier supports them).** Resolved from `$PATH` or
+  `~/.dotnet/tools/csharpier`. The buffer goes through a sibling temp
+  file so the project's `.csharpierrc` / `.editorconfig` resolution
+  still works. csharpier 1.x prints `Is an unsupported file type` and
+  exits 0 for Razor; the dispatch detects that signal and falls back.
+- **`.editorconfig`-driven indent normaliser for `.cshtml` / `.razor`.**
+  Reflows leading whitespace per `indent_style` and `indent_size` —
+  tabs → spaces, spaces → tabs, with intermediate columns preserved.
+  Inner whitespace (column-aligned attributes, mid-line tabs) is left
+  alone. Wired into the csharpier fallback so saving a Razor file
+  applies the indent settings even though csharpier itself doesn't
+  format it.
+- **gofmt / goimports for `.go`.** Prefers `goimports` when on `$PATH`
+  (formats + organises imports), falls back to plain `gofmt`. Both read
+  stdin and write to stdout so no temp file is needed.
+- **Visual-mode `p` / `P` replaces the selection.** Previously only
+  Normal-mode parsed the put keys. Now `viw` → `p`, `V<motion>` →
+  `p`, and block-select → `p` all swap the visual span with the
+  register's contents. Block paste deletes the rectangle and inserts
+  at the corner; charwise + linewise behave like Vim's `cpoptions-=>`
+  with a linewise-over-charwise trim.
+- **Paste from the OS clipboard.** `p` / `P` against the unnamed /
+  `+` / `*` registers consult the clipboard first — anything you
+  copied in another app wins over the in-memory yank. Falls back to
+  the in-memory register when the clipboard is empty, locked, or
+  non-text. Linewise heuristic: trailing newline *and* interior
+  newline → linewise paste; single line with trailing newline stays
+  charwise.
 - **.NET Core debugger via DAP.** New `src/dap/` module spawns Samsung's
   netcoredbg (looked up on `$PATH`), drives the full Debug Adapter
   Protocol handshake (initialize → launch → setBreakpoints →
@@ -72,6 +115,30 @@ follows [Semantic Versioning](https://semver.org/).
   in the chrome layer.
 
 ### Fixed
+- **CRLF files clobbered inline diagnostics.** `Buffer::from_path` kept
+  every line's trailing `\r`; the renderer stripped only `\n`, so the
+  `\r` reached the terminal and reset the cursor to column 0 right
+  before the Error-Lens inline diagnostic painted on top of the
+  source. Files with CRLF on the line a diagnostic landed on (common
+  in Vettvangur's mixed-line-ending `.cs` files) rendered as
+  `● Unnecessary using directive.PublishedContent;` with the leading
+  source obliterated. Now normalises `\r\n` → `\n` on load + on
+  disk-watch reload, with a defensive trailing-`\r` strip in the
+  renderer as belt-and-suspenders for paste / LSP-applied edits.
+- **Mouse clicks on tab-indented lines landed past the click.** The
+  click handler treated the post-gutter screen column as the buffer
+  char column directly. A tab takes `TAB_WIDTH` visual cells but one
+  buffer char, so two leading tabs (visual col 8) used to map to char
+  8 — well past `<partial` on the line. The handler now replays the
+  renderer's display-width walk to translate visual position back to
+  char position; drag selection shares the same mapping.
+- **Razor closing-tag names rendered uncoloured.** The post-pass's
+  child-node skip set listed `<`, `>`, `/>`, `=`, `"` but missed
+  `</`, so the scanner treated the closing-tag opener as a nested
+  child and stopped before reaching `section` / `div`. Added `</`
+  to the skip set so opening and closing tag names match in colour,
+  plus an overlay capture so the `</` token itself paints with the
+  punctuation tone like `<` / `>` / `/>`.
 - **Stale frames + locals after step / breakpoint hit.** `stackTrace`,
   `scopes`, and `variables` responses mutated session state but didn't
   emit a user-facing `DapEvent`, so the main loop's `events.is_empty()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,106 @@ follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **.NET Core debugger via DAP.** New `src/dap/` module spawns Samsung's
+  netcoredbg (looked up on `$PATH`), drives the full Debug Adapter
+  Protocol handshake (initialize → launch → setBreakpoints →
+  configurationDone), and surfaces stop / step / output events in a new
+  bottom debug pane. `:debug` (or `<leader>ds`) auto-builds the project
+  via `dotnet build` and auto-resolves the dll under `bin/Debug/net*/`,
+  preferring `<project>.dll` from the most recently built target. The
+  adapter registry in `src/dap/specs.rs` is adapter-agnostic — additional
+  adapters (delve, debugpy, lldb-dap) plug in with one struct entry.
+  Tested against .NET 10 on Apple Silicon.
+- **Bottom debug pane.** `:dappane` / `<leader>dp` toggles a split below
+  the editor (painted in the tab bar's Mantle shade so it reads as
+  chrome rather than a buffer split). The pane silently no-ops on
+  terminals too short to keep the editor usable. Header shows
+  `DEBUG │ <adapter> · <status>`; body splits into call stack +
+  locals on the left, debug-console tail on the right.
+- **`Mode::DebugPane` for in-pane navigation.** `<leader>df` focuses
+  the pane; `j`/`k`/`g`/`G` move the locals selection (with auto-follow
+  scroll), `Enter` / `Tab` / `<space>` expand a structured value,
+  `Ctrl-Y` / `Ctrl-E` free-scroll the left column without losing the
+  selection, `J` / `K` scroll the console column, `c`/`n`/`i`/`O` step
+  without leaving the pane, `:` enters the command line, `Esc` returns
+  to Normal.
+- **Variable expansion in the locals tree.** Structured locals render
+  with ▶ / ▼ markers; expansion lazily fetches `children` per
+  `variables_reference` and caches them. Children fetched concurrently
+  are routed back to the right parent via a `request_seq → vref` map.
+  All maps clear on `stopped` / `continued` — DAP doesn't promise vref
+  stability between stops.
+- **Breakpoint and current-PC gutter markers.** User breakpoints render
+  as ● in the sign column; the currently-stopped top frame renders as
+  ▶ (Catppuccin Peach). Both win over LSP diagnostic severity on the
+  same line.
+- **Visual Studio / Rider F-key bindings.** `F5` continue (or start
+  when no session), `Shift+F5` stop, `F9` toggle breakpoint, `F10`
+  step over, `F11` step into, `Shift+F11` step out. Work in any
+  editor mode so the muscle memory carries through Insert / DebugPane.
+- **Auto-jump to stopped frame.** When a `stopped` event arrives, the
+  editor opens the source of the top frame (if not already open),
+  jumps the cursor onto the paused line, and the gutter ▶ marker
+  lands there. Scroll positions reset so each new stop starts from a
+  predictable viewport.
+- **Adapter stderr surfaced in the pane.** Any line netcoredbg writes
+  to stderr streams into the debug-console buffer and the pane status
+  header — adapter crashes no longer look like silent hangs. An
+  unexpected `Child::try_wait` exit becomes an `AdapterError` event so
+  the user sees the cause instead of a frozen pane.
+- **Unverified-breakpoint surfacing.** netcoredbg's `setBreakpoints`
+  response includes per-breakpoint `verified` flags; unverified entries
+  now stream into the console + status line so the user spots a
+  missing-PDB / wrong-line / "bind by pattern" misfire instead of
+  silently never hitting.
+
+### Changed
+- **`<leader>d` is the debugger sub-menu.** Doc symbols moved from
+  top-level `<leader>o` to `<leader>do`; Workspace symbols from
+  `<leader>S` to `<leader>dS`. The leader-pick popup lists `+Debug`
+  alongside `+Buffer`. The leader-entry hints update with the new
+  mapping.
+- **Debug pane uses the tab-bar's Mantle shade.** Previously rendered
+  in Surface0 / Surface1, which read as a second buffer split. Now
+  both header and body paint as `#181825` so the pane visually sits
+  in the chrome layer.
+
+### Fixed
+- **Stale frames + locals after step / breakpoint hit.** `stackTrace`,
+  `scopes`, and `variables` responses mutated session state but didn't
+  emit a user-facing `DapEvent`, so the main loop's `events.is_empty()`
+  gate skipped the re-render and the ▶ marker + locals appeared only
+  on the next keypress. `DapManager::drain` now returns
+  `(events, progress)` and the main loop renders on either condition.
+- **DAP polling latency.** The main loop's 100ms poll ceiling stacked
+  ~500ms of perceived lag onto a single step (4-5 request/response
+  round-trips, each waiting on the next poll wake). The poll budget
+  now caps at 16ms while `DapManager::is_active()`; idle keeps the
+  100ms cadence.
+- **Deep stacks hiding locals.** With `justMyCode=false`, an ASP.NET
+  breakpoint produced 10-15 framework frames that filled the left
+  column and pushed locals off-screen. The renderer used to cap the
+  frame list, but now every frame is in the list and the column
+  scrolls — `Ctrl-Y` / `Ctrl-E` peek upward without losing the
+  selection.
+- **`adapterID` for netcoredbg.** The adapter keys behaviour on the
+  well-known `coreclr` adapter id; passing our internal `"dotnet"` key
+  produced a degraded session. The initialize request now sends
+  `adapterID: "coreclr"` while the editor-side registry continues to
+  use the `dotnet` key.
+- **Lambdas inside minimal-API endpoints never hitting.** Default
+  `justMyCode=true` caused netcoredbg to rebind breakpoints inside
+  endpoint lambdas to the nearest user-code sequence point (the
+  `MapGet` registration line), so they fired once during startup and
+  never again on request. Switched the default to `false`; the
+  `breakpoint` DAP event is now handled so adapter-side rebinds
+  propagate to the gutter.
+- **netcoredbg empty stackTrace immediately after stop.** Some adapters
+  refuse to populate `stackTrace` until the client has called
+  `threads`. The `stopped` event now fires both requests back-to-back
+  so the frame list is populated by the time `stackTrace` returns.
+
 ## [0.1.2] - 2026-05-11
 
 ### Changed

--- a/UP_NEXT.md
+++ b/UP_NEXT.md
@@ -41,11 +41,6 @@ doesn't drift out of memory.
 
 ## Bigger projects
 
-- **Split windows / panes.** `:vsp` / `:sp`. The biggest functional
-  gap. App's single-buffer rendering assumes one viewport; adding
-  splits means a `Window` tree, per-window cursor/viewport, and the
-  layout math in `render.rs` becomes substantial. High ROI but real
-  work.
 - **Quickfix list.** Step through compile errors / grep results /
   LSP diagnostics with `:cnext`. The pickers cover discovery; a
   quickfix list covers iteration.
@@ -56,9 +51,6 @@ doesn't drift out of memory.
 - **Git gutter + inline blame.** `+`/`~`/`-` sign-column markers for
   changed lines; `]c`/`[c` hunks navigation; `<leader>gb` toggle for
   per-line blame. Sign column already exists for diagnostics.
-- **DAP (debugger).** Biggest lift on the list, biggest payoff if
-  Rust / Go is the day job. Would touch the LSP module's
-  send-request infrastructure to bolt on a parallel DAP client.
 - **Multi-cursor across motions / operators.** Today only Insert-
   mode typing / Backspace mirror. Mirroring `dw` / `cw` / `yy` etc.
   across N cursors requires every primitive in `app/edit.rs` and

--- a/src/app.rs
+++ b/src/app.rs
@@ -126,6 +126,11 @@ pub struct App {
     /// editor area; height is computed from terminal size in `view.rs`.
     /// Starts closed; toggled by `:dappane` and forced open by `:debug`.
     pub debug_pane_open: bool,
+    /// Index into the flat locals tree of the currently-selected row when
+    /// `Mode::DebugPane` has focus. Bounded against the live tree at
+    /// access time — vrefs can shift across stops, so the renderer and
+    /// key handler clamp before use.
+    pub dap_pane_cursor: usize,
     /// Active yank flash, if any. Drained automatically by the main loop
     /// once its `expires_at` deadline passes.
     pub yank_highlight: Option<YankHighlight>,
@@ -237,6 +242,7 @@ impl App {
             ),
             show_start_page,
             debug_pane_open: false,
+            dap_pane_cursor: 0,
             yank_highlight: None,
             pending_code_actions: Vec::new(),
             rename_anchor: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -131,6 +131,14 @@ pub struct App {
     /// access time — vrefs can shift across stops, so the renderer and
     /// key handler clamp before use.
     pub dap_pane_cursor: usize,
+    /// Top of the left column's viewport (frames + separator + locals).
+    /// Driven by `j`/`k` (auto-follow the selection) and `Ctrl-Y`/`Ctrl-E`
+    /// (free scroll without moving selection).
+    pub dap_left_scroll: usize,
+    /// Number of "latest" console-output rows hidden below the right
+    /// column's viewport. `0` keeps the latest line glued to the bottom;
+    /// `J`/`K` scrolls into the older history.
+    pub dap_right_scroll: usize,
     /// Active yank flash, if any. Drained automatically by the main loop
     /// once its `expires_at` deadline passes.
     pub yank_highlight: Option<YankHighlight>,
@@ -243,6 +251,8 @@ impl App {
             show_start_page,
             debug_pane_open: false,
             dap_pane_cursor: 0,
+            dap_left_scroll: 0,
+            dap_right_scroll: 0,
             yank_highlight: None,
             pending_code_actions: Vec::new(),
             rename_anchor: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,7 @@
 //! - [`health`]: `:health` command output
 
 mod buffers;
+mod dap_glue;
 mod dispatch;
 mod edit;
 mod health;
@@ -101,9 +102,8 @@ pub struct App {
     pub config: Config,
     pub editorconfig: EditorConfig,
     pub lsp: LspManager,
-    /// Debug session manager. Phase 1 holds only the user's breakpoint
-    /// table; Phase 2 wires actual sessions through this.
-    #[allow(dead_code)]
+    /// Debug session manager — owns the user's breakpoint table and the
+    /// currently-active DAP session (if any).
     pub dap: DapManager,
     /// Last buffer version we shipped to the LSP, keyed by path.
     pub last_sent_version: HashMap<PathBuf, u64>,
@@ -330,6 +330,11 @@ impl App {
                             title: "Buffer".into(),
                             entries: state::buffer_prefix_entries(),
                         })
+                    } else if self.pending.awaiting_debug_leader {
+                        Some(WhichKeyState {
+                            title: "Debug".into(),
+                            entries: state::debug_prefix_entries(),
+                        })
                     } else {
                         None
                     };
@@ -343,6 +348,11 @@ impl App {
             let (events, _more) = self.lsp.drain();
             if !events.is_empty() {
                 self.handle_lsp_events(events);
+                needs_render = true;
+            }
+            let dap_events = self.dap.drain();
+            if !dap_events.is_empty() {
+                self.handle_dap_events(dap_events);
                 needs_render = true;
             }
             // Drop the yank flash once its deadline has passed so the next

--- a/src/app.rs
+++ b/src/app.rs
@@ -375,9 +375,16 @@ impl App {
                 self.handle_lsp_events(events);
                 needs_render = true;
             }
-            let dap_events = self.dap.drain();
-            if !dap_events.is_empty() {
+            let (dap_events, dap_progress) = self.dap.drain();
+            let had_dap_events = !dap_events.is_empty();
+            if had_dap_events {
                 self.handle_dap_events(dap_events);
+            }
+            // Silent protocol replies (stackTrace / scopes / variables)
+            // mutate visible session state without producing a user-facing
+            // event — render anyway so the pane reflects the new frames
+            // and locals immediately instead of on the next keypress.
+            if had_dap_events || dap_progress {
                 needs_render = true;
             }
             // Drop the yank flash once its deadline has passed so the next

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,6 +52,7 @@ use std::time::{Duration, Instant};
 use crate::buffer::Buffer;
 use crate::config::Config;
 use crate::cursor::Cursor;
+use crate::dap::DapManager;
 use crate::editorconfig::EditorConfig;
 use crate::lang::HighlightCache;
 use crate::lsp::{CodeActionItem, InlayHint, LspManager, SignatureHelp};
@@ -100,6 +101,10 @@ pub struct App {
     pub config: Config,
     pub editorconfig: EditorConfig,
     pub lsp: LspManager,
+    /// Debug session manager. Phase 1 holds only the user's breakpoint
+    /// table; Phase 2 wires actual sessions through this.
+    #[allow(dead_code)]
+    pub dap: DapManager,
     /// Last buffer version we shipped to the LSP, keyed by path.
     pub last_sent_version: HashMap<PathBuf, u64>,
     /// Wall-clock of the last `did_change` flush. Drives the keystroke
@@ -117,6 +122,10 @@ pub struct App {
     /// True when binvim was launched with no path — render the start page in
     /// place of the empty buffer until the user opens something.
     pub show_start_page: bool,
+    /// Bottom debug pane visibility. When open it steals rows from the
+    /// editor area; height is computed from terminal size in `view.rs`.
+    /// Starts closed; toggled by `:dappane` and forced open by `:debug`.
+    pub debug_pane_open: bool,
     /// Active yank flash, if any. Drained automatically by the main loop
     /// once its `expires_at` deadline passes.
     pub yank_highlight: Option<YankHighlight>,
@@ -215,6 +224,7 @@ impl App {
             config: Config::load(),
             editorconfig: EditorConfig::default(),
             lsp: LspManager::new(),
+            dap: DapManager::new(),
             last_sent_version: HashMap::new(),
             last_lsp_sync_at: Instant::now(),
             completion: None,
@@ -226,6 +236,7 @@ impl App {
                 &std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             ),
             show_start_page,
+            debug_pane_open: false,
             yank_highlight: None,
             pending_code_actions: Vec::new(),
             rename_anchor: None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -311,6 +311,15 @@ impl App {
                 }
                 None => Duration::from_millis(100),
             };
+            // Active debug session — DAP stepping / breakpoint hits
+            // cascade 4-5 request/response round-trips per user action
+            // (stopped → threads → stackTrace → scopes → variables), and
+            // each round-trip waits for the next poll wake-up to drain
+            // the reader channel. Tightening the budget here turns
+            // stepping from "noticeably slow" into "instant".
+            if self.dap.is_active() {
+                poll_dur = poll_dur.min(Duration::from_millis(16));
+            }
             // A live yank flash needs us to wake up at its deadline so the
             // highlight clears on time.
             if let Some(h) = self.yank_highlight.as_ref() {

--- a/src/app/dap_glue.rs
+++ b/src/app/dap_glue.rs
@@ -1,0 +1,195 @@
+//! DAP event handling and `:debug` / `:dap*` ex-command dispatch.
+//!
+//! Mirrors `app/lsp_glue.rs`: the main loop drains events off the manager
+//! and we react here. Editor-side concerns (opening a buffer at the
+//! stopped frame, surfacing status messages, opening the bottom pane on
+//! session start) live here, not in `dap/manager.rs`.
+
+use crate::command::DebugSubCmd;
+use crate::dap::{adapter_for_workspace, DapEvent, SessionState, StepKind};
+
+impl super::App {
+    pub(super) fn dispatch_debug(&mut self, sub: DebugSubCmd) {
+        match sub {
+            DebugSubCmd::Start => self.dap_start_session(),
+            DebugSubCmd::Stop => self.dap_stop_session(),
+            DebugSubCmd::Break => self.dap_toggle_breakpoint(),
+            DebugSubCmd::ClearBreakpointsInFile => self.dap_clear_breakpoints_in_file(),
+            DebugSubCmd::Continue => self.dap_step(StepKind::Continue),
+            DebugSubCmd::Next => self.dap_step(StepKind::Next),
+            DebugSubCmd::StepIn => self.dap_step(StepKind::StepIn),
+            DebugSubCmd::StepOut => self.dap_step(StepKind::StepOut),
+            DebugSubCmd::PaneToggle => {
+                self.debug_pane_open = !self.debug_pane_open;
+                self.adjust_viewport();
+                self.status_msg = if self.debug_pane_open {
+                    "debug pane: open".into()
+                } else {
+                    "debug pane: closed".into()
+                };
+            }
+        }
+    }
+
+    fn dap_start_session(&mut self) {
+        let start_dir = self
+            .buffer
+            .path
+            .as_ref()
+            .and_then(|p| p.parent().map(|p| p.to_path_buf()))
+            .unwrap_or_else(|| {
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."))
+            });
+        let Some((adapter, root)) = adapter_for_workspace(&start_dir) else {
+            self.status_msg =
+                "debug: no adapter found for this workspace (need a *.csproj/*.sln)".into();
+            return;
+        };
+        // Surface the build progress before the blocking prelaunch step.
+        // We can't redraw mid-call (the prelaunch runs synchronously) but
+        // setting the status here means it's at least visible after the
+        // build finishes if there was no error.
+        self.status_msg = format!("debug: {} ({})", adapter.key, root.display());
+        // Force the pane open so the user can see status as the handshake
+        // unfolds.
+        self.debug_pane_open = true;
+        self.adjust_viewport();
+        match self.dap.start_session(adapter, root) {
+            Ok(()) => {
+                self.status_msg = "debug: session starting".into();
+            }
+            Err(e) => {
+                self.status_msg = format!("debug: {e}");
+            }
+        }
+    }
+
+    fn dap_stop_session(&mut self) {
+        if !self.dap.is_active() {
+            self.status_msg = "debug: no active session".into();
+            return;
+        }
+        self.dap.stop_session();
+        self.status_msg = "debug: session terminated".into();
+    }
+
+    fn dap_toggle_breakpoint(&mut self) {
+        let Some(path) = self.buffer.path.clone() else {
+            self.status_msg = "debug: buffer has no path".into();
+            return;
+        };
+        let abs = path.canonicalize().unwrap_or(path);
+        // Cursor.line is 0-based; DAP / the user-visible line number is 1-based.
+        let line = self.cursor.line + 1;
+        let added = self.dap.toggle_breakpoint(&abs, line);
+        self.status_msg = if added {
+            format!("breakpoint set at {}:{}", abs.display(), line)
+        } else {
+            format!("breakpoint cleared at {}:{}", abs.display(), line)
+        };
+    }
+
+    fn dap_clear_breakpoints_in_file(&mut self) {
+        let Some(path) = self.buffer.path.clone() else {
+            self.status_msg = "debug: buffer has no path".into();
+            return;
+        };
+        let abs = path.canonicalize().unwrap_or(path);
+        let n = self.dap.clear_breakpoints_in_file(&abs);
+        self.status_msg = match n {
+            0 => "debug: no breakpoints in this file".into(),
+            1 => "debug: cleared 1 breakpoint".into(),
+            n => format!("debug: cleared {n} breakpoints"),
+        };
+    }
+
+    fn dap_step(&mut self, kind: StepKind) {
+        if !self.dap.is_active() {
+            self.status_msg = "debug: no active session".into();
+            return;
+        }
+        let stopped = self
+            .dap
+            .session
+            .as_ref()
+            .map(|s| matches!(s.state, SessionState::Stopped { .. }))
+            .unwrap_or(false);
+        if !stopped {
+            self.status_msg = "debug: program is not paused".into();
+            return;
+        }
+        self.dap.step(kind);
+    }
+
+    pub(super) fn handle_dap_events(&mut self, events: Vec<DapEvent>) {
+        for ev in events {
+            match ev {
+                DapEvent::Initialized => {}
+                DapEvent::Stopped {
+                    thread_id, reason, ..
+                } => {
+                    self.status_msg = format!("debug: stopped — {} (thread {})", reason, thread_id);
+                    self.dap_jump_to_top_frame();
+                }
+                DapEvent::Continued { .. } => {
+                    self.status_msg = "debug: running".into();
+                }
+                DapEvent::Output(_) => {}
+                DapEvent::Thread { reason, thread_id } => {
+                    if reason == "exited" {
+                        self.status_msg = format!("debug: thread {} exited", thread_id);
+                    }
+                }
+                DapEvent::Breakpoint { .. } => {}
+                DapEvent::Exited { exit_code } => {
+                    self.status_msg = format!("debug: debuggee exited ({})", exit_code);
+                }
+                DapEvent::Terminated => {
+                    self.status_msg = "debug: session ended".into();
+                    self.dap.session = None;
+                }
+                DapEvent::AdapterError(msg) => {
+                    self.status_msg = format!("debug error: {msg}");
+                }
+            }
+        }
+    }
+
+    /// On a `stopped` event the manager has already requested the stack
+    /// trace; by the time the renderer's next frame runs the top frame
+    /// has typically arrived. Open the source file (if needed) and put
+    /// the cursor on the frame's line so the user immediately sees where
+    /// execution paused.
+    fn dap_jump_to_top_frame(&mut self) {
+        let Some(session) = self.dap.session.as_ref() else {
+            return;
+        };
+        let Some(top) = session.frames.first() else {
+            return;
+        };
+        let Some(path) = top.source.clone() else {
+            return;
+        };
+        // DAP frames carry 1-based line numbers; binvim's cursor is 0-based.
+        let line = top.line.saturating_sub(1);
+        let col = top.column.saturating_sub(1);
+        let already_open = self
+            .buffer
+            .path
+            .as_ref()
+            .map(|p| p == &path || p.canonicalize().ok() == path.canonicalize().ok())
+            .unwrap_or(false);
+        if !already_open {
+            self.push_jump();
+            if let Err(e) = self.open_buffer(path) {
+                self.status_msg = format!("debug: cannot open frame source: {e}");
+                return;
+            }
+        }
+        self.cursor.line = line;
+        self.cursor.col = col;
+        self.cursor.want_col = col;
+        self.clamp_cursor_normal();
+        self.adjust_viewport();
+    }
+}

--- a/src/app/dap_glue.rs
+++ b/src/app/dap_glue.rs
@@ -5,7 +5,7 @@
 //! stopped frame, surfacing status messages, opening the bottom pane on
 //! session start) live here, not in `dap/manager.rs`.
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::command::DebugSubCmd;
 use crate::dap::{adapter_for_workspace, flat_locals_view, DapEvent, SessionState, StepKind};
@@ -115,6 +115,60 @@ impl super::App {
             KeyCode::Char(':') => {
                 self.mode = Mode::Command;
                 self.cmdline.clear();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Visual Studio / Rider-style debug shortcut keys, dispatched
+    /// regardless of editor mode so the muscle memory works during
+    /// editing too. Returns `true` if the key was consumed.
+    ///
+    /// - `F5`        — start session (or continue if already paused)
+    /// - `Shift+F5`  — stop session
+    /// - `F9`        — toggle breakpoint at cursor
+    /// - `F10`       — step over (next)
+    /// - `F11`       — step into
+    /// - `Shift+F11` — step out
+    pub(super) fn try_handle_debug_function_key(&mut self, k: &KeyEvent) -> bool {
+        let shift = k.modifiers.contains(KeyModifiers::SHIFT);
+        let modless = k
+            .modifiers
+            .difference(KeyModifiers::SHIFT)
+            .is_empty();
+        if !modless {
+            return false;
+        }
+        match k.code {
+            KeyCode::F(5) if shift => {
+                self.dispatch_debug(DebugSubCmd::Stop);
+                true
+            }
+            KeyCode::F(5) => {
+                // F5 doubles as "start if there's no session yet" so the
+                // user doesn't have to remember a separate Start binding.
+                if self.dap.is_active() {
+                    self.dispatch_debug(DebugSubCmd::Continue);
+                } else {
+                    self.dispatch_debug(DebugSubCmd::Start);
+                }
+                true
+            }
+            KeyCode::F(9) => {
+                self.dispatch_debug(DebugSubCmd::Break);
+                true
+            }
+            KeyCode::F(10) => {
+                self.dispatch_debug(DebugSubCmd::Next);
+                true
+            }
+            KeyCode::F(11) if shift => {
+                self.dispatch_debug(DebugSubCmd::StepOut);
+                true
+            }
+            KeyCode::F(11) => {
+                self.dispatch_debug(DebugSubCmd::StepIn);
                 true
             }
             _ => false,

--- a/src/app/dap_glue.rs
+++ b/src/app/dap_glue.rs
@@ -45,8 +45,20 @@ impl super::App {
             self.adjust_viewport();
         }
         self.dap_pane_cursor = 0;
+        self.dap_right_scroll = 0;
+        // Park the left column on the last couple of frames so the
+        // separator and first locals are visible by default — without
+        // hiding the user-relevant frame context above.
+        let frames_len = self
+            .dap
+            .session
+            .as_ref()
+            .map(|s| s.frames.len())
+            .unwrap_or(0);
+        self.dap_left_scroll = frames_len.saturating_sub(2);
         self.mode = Mode::DebugPane;
-        self.status_msg = "pane: j/k navigate · Enter/Tab expand · Esc exits".into();
+        self.status_msg =
+            "pane: j/k navigate · ^Y/^E scroll · J/K log · Enter expand · Esc exits".into();
     }
 
     pub(super) fn dap_exit_pane_focus(&mut self) {
@@ -59,6 +71,7 @@ impl super::App {
     /// Key dispatch for `Mode::DebugPane`. Returns `true` if the key was
     /// consumed (the caller skips the normal-mode dispatch in that case).
     pub(super) fn handle_debug_pane_key(&mut self, key: KeyEvent) -> bool {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         let locals_len = self
             .dap
             .session
@@ -70,26 +83,59 @@ impl super::App {
                 self.dap_exit_pane_focus();
                 true
             }
+            // Ctrl-Y / Ctrl-E: scroll the left column without moving the
+            // selection — Vim-convention free scroll for peeking at
+            // frames above the locals.
+            KeyCode::Char('y') if ctrl => {
+                self.dap_left_scroll = self.dap_left_scroll.saturating_sub(1);
+                true
+            }
+            KeyCode::Char('e') if ctrl => {
+                self.dap_left_scroll = self
+                    .dap_left_scroll
+                    .saturating_add(1)
+                    .min(self.dap_left_scroll_max());
+                true
+            }
             KeyCode::Char('j') | KeyCode::Down => {
                 if locals_len > 0 {
                     self.dap_pane_cursor = (self.dap_pane_cursor + 1).min(locals_len - 1);
+                    self.dap_follow_selection_in_left_column();
                 }
                 true
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.dap_pane_cursor = self.dap_pane_cursor.saturating_sub(1);
+                self.dap_follow_selection_in_left_column();
                 true
             }
             KeyCode::Char('g') => {
                 self.dap_pane_cursor = 0;
+                self.dap_follow_selection_in_left_column();
                 true
             }
             KeyCode::Char('G') => {
                 self.dap_pane_cursor = locals_len.saturating_sub(1);
+                self.dap_follow_selection_in_left_column();
+                true
+            }
+            // Right column scrolling — capital J/K so lowercase stays
+            // bound to locals navigation. J pages toward the latest log
+            // line; K pages back into older history.
+            KeyCode::Char('J') => {
+                self.dap_right_scroll = self.dap_right_scroll.saturating_sub(1);
+                true
+            }
+            KeyCode::Char('K') => {
+                self.dap_right_scroll = self
+                    .dap_right_scroll
+                    .saturating_add(1)
+                    .min(self.dap_right_scroll_max());
                 true
             }
             KeyCode::Enter | KeyCode::Tab | KeyCode::Char(' ') => {
                 self.dap_pane_toggle_at_cursor();
+                self.dap_follow_selection_in_left_column();
                 true
             }
             // Stepping bindings while focus is in the pane — saves an
@@ -118,6 +164,69 @@ impl super::App {
                 true
             }
             _ => false,
+        }
+    }
+
+    /// Maximum valid value for `dap_left_scroll`. The total left-column
+    /// row count (frames + optional separator + locals tree) minus the
+    /// number of body rows the pane currently has.
+    pub(super) fn dap_left_scroll_max(&self) -> usize {
+        let Some(session) = self.dap.session.as_ref() else {
+            return 0;
+        };
+        let flat = flat_locals_view(session);
+        let total = if flat.is_empty() {
+            session.frames.len()
+        } else {
+            session.frames.len() + 1 + flat.len()
+        };
+        let body_rows = self.debug_pane_rows().saturating_sub(1);
+        total.saturating_sub(body_rows)
+    }
+
+    /// Maximum valid value for `dap_right_scroll`. Counts every output
+    /// line currently in the buffer; the buffer is bounded by
+    /// `OUTPUT_LOG_CAP` so this is cheap.
+    pub(super) fn dap_right_scroll_max(&self) -> usize {
+        let total_lines: usize = self
+            .dap
+            .output_buffer
+            .iter()
+            .map(|o| o.output.lines().count().max(1))
+            .sum();
+        let body_rows = self.debug_pane_rows().saturating_sub(1);
+        total_lines.saturating_sub(body_rows)
+    }
+
+    /// Adjust `dap_left_scroll` so the currently-selected local is in
+    /// the visible viewport. Called after every selection-moving key.
+    fn dap_follow_selection_in_left_column(&mut self) {
+        let Some(session) = self.dap.session.as_ref() else {
+            return;
+        };
+        let frames_len = session.frames.len();
+        let flat_len = flat_locals_view(session).len();
+        if flat_len == 0 {
+            return;
+        }
+        let cursor = self.dap_pane_cursor.min(flat_len - 1);
+        // Locals occupy rows `[frames_len + 1, frames_len + 1 + flat_len)`
+        // — the `+1` accounts for the "── Locals ──" separator row.
+        let selected_abs = frames_len + 1 + cursor;
+        let body_rows = self.debug_pane_rows().saturating_sub(1);
+        if body_rows == 0 {
+            return;
+        }
+        if selected_abs < self.dap_left_scroll {
+            self.dap_left_scroll = selected_abs;
+        }
+        let last_visible = self.dap_left_scroll + body_rows;
+        if selected_abs >= last_visible {
+            self.dap_left_scroll = selected_abs + 1 - body_rows;
+        }
+        let max = self.dap_left_scroll_max();
+        if self.dap_left_scroll > max {
+            self.dap_left_scroll = max;
         }
     }
 
@@ -302,6 +411,13 @@ impl super::App {
                     thread_id, reason, ..
                 } => {
                     self.status_msg = format!("debug: stopped — {} (thread {})", reason, thread_id);
+                    // Reset the pane scroll positions so the user sees
+                    // the new stop's frame + locals from a sensible
+                    // starting position rather than wherever the previous
+                    // stop's viewport happened to land.
+                    self.dap_pane_cursor = 0;
+                    self.dap_right_scroll = 0;
+                    self.dap_left_scroll = 0;
                     self.dap_jump_to_top_frame();
                 }
                 DapEvent::Continued { .. } => {

--- a/src/app/dap_glue.rs
+++ b/src/app/dap_glue.rs
@@ -5,8 +5,11 @@
 //! stopped frame, surfacing status messages, opening the bottom pane on
 //! session start) live here, not in `dap/manager.rs`.
 
+use crossterm::event::{KeyCode, KeyEvent};
+
 use crate::command::DebugSubCmd;
-use crate::dap::{adapter_for_workspace, DapEvent, SessionState, StepKind};
+use crate::dap::{adapter_for_workspace, flat_locals_view, DapEvent, SessionState, StepKind};
+use crate::mode::Mode;
 
 impl super::App {
     pub(super) fn dispatch_debug(&mut self, sub: DebugSubCmd) {
@@ -28,7 +31,115 @@ impl super::App {
                     "debug pane: closed".into()
                 };
             }
+            DebugSubCmd::FocusPane => self.dap_enter_pane_focus(),
         }
+    }
+
+    fn dap_enter_pane_focus(&mut self) {
+        if !self.dap.is_active() {
+            self.status_msg = "debug: no active session".into();
+            return;
+        }
+        if !self.debug_pane_open {
+            self.debug_pane_open = true;
+            self.adjust_viewport();
+        }
+        self.dap_pane_cursor = 0;
+        self.mode = Mode::DebugPane;
+        self.status_msg = "pane: j/k navigate · Enter/Tab expand · Esc exits".into();
+    }
+
+    pub(super) fn dap_exit_pane_focus(&mut self) {
+        if self.mode == Mode::DebugPane {
+            self.mode = Mode::Normal;
+            self.status_msg.clear();
+        }
+    }
+
+    /// Key dispatch for `Mode::DebugPane`. Returns `true` if the key was
+    /// consumed (the caller skips the normal-mode dispatch in that case).
+    pub(super) fn handle_debug_pane_key(&mut self, key: KeyEvent) -> bool {
+        let locals_len = self
+            .dap
+            .session
+            .as_ref()
+            .map(|s| flat_locals_view(s).len())
+            .unwrap_or(0);
+        match key.code {
+            KeyCode::Esc => {
+                self.dap_exit_pane_focus();
+                true
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if locals_len > 0 {
+                    self.dap_pane_cursor = (self.dap_pane_cursor + 1).min(locals_len - 1);
+                }
+                true
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.dap_pane_cursor = self.dap_pane_cursor.saturating_sub(1);
+                true
+            }
+            KeyCode::Char('g') => {
+                self.dap_pane_cursor = 0;
+                true
+            }
+            KeyCode::Char('G') => {
+                self.dap_pane_cursor = locals_len.saturating_sub(1);
+                true
+            }
+            KeyCode::Enter | KeyCode::Tab | KeyCode::Char(' ') => {
+                self.dap_pane_toggle_at_cursor();
+                true
+            }
+            // Stepping bindings while focus is in the pane — saves an
+            // Esc + <leader>d{c,n,i,O} round-trip during inspection.
+            KeyCode::Char('c') => {
+                self.dap.step(StepKind::Continue);
+                true
+            }
+            KeyCode::Char('n') => {
+                self.dap.step(StepKind::Next);
+                true
+            }
+            KeyCode::Char('i') => {
+                self.dap.step(StepKind::StepIn);
+                true
+            }
+            KeyCode::Char('O') => {
+                self.dap.step(StepKind::StepOut);
+                true
+            }
+            // Ex-command escape hatch so the user can `:dapstop`/etc from
+            // inside the pane without having to bounce through Normal.
+            KeyCode::Char(':') => {
+                self.mode = Mode::Command;
+                self.cmdline.clear();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn dap_pane_toggle_at_cursor(&mut self) {
+        // Pull out the vref to toggle in a tight `&self` scope so the
+        // ensuing `toggle_expanded` call can take `&mut self.dap`.
+        let vref = {
+            let Some(session) = self.dap.session.as_ref() else {
+                return;
+            };
+            let flat = flat_locals_view(session);
+            if flat.is_empty() {
+                return;
+            }
+            let idx = self.dap_pane_cursor.min(flat.len() - 1);
+            let row = &flat[idx];
+            if !row.expandable {
+                return;
+            }
+            row.var.variables_reference
+        };
+        self.dap.toggle_expanded(vref);
     }
 
     fn dap_start_session(&mut self) {
@@ -71,6 +182,9 @@ impl super::App {
         }
         self.dap.stop_session();
         self.status_msg = "debug: session terminated".into();
+        if self.mode == Mode::DebugPane {
+            self.mode = Mode::Normal;
+        }
         // Close the bottom pane on stop — the session is gone, there's
         // nothing useful to look at, and reclaiming the rows snaps the
         // editor back to its usual height.
@@ -152,6 +266,9 @@ impl super::App {
                 DapEvent::Terminated => {
                     self.status_msg = "debug: session ended".into();
                     self.dap.session = None;
+                    if self.mode == Mode::DebugPane {
+                        self.mode = Mode::Normal;
+                    }
                     if self.debug_pane_open {
                         self.debug_pane_open = false;
                         self.adjust_viewport();

--- a/src/app/dap_glue.rs
+++ b/src/app/dap_glue.rs
@@ -71,6 +71,13 @@ impl super::App {
         }
         self.dap.stop_session();
         self.status_msg = "debug: session terminated".into();
+        // Close the bottom pane on stop — the session is gone, there's
+        // nothing useful to look at, and reclaiming the rows snaps the
+        // editor back to its usual height.
+        if self.debug_pane_open {
+            self.debug_pane_open = false;
+            self.adjust_viewport();
+        }
     }
 
     fn dap_toggle_breakpoint(&mut self) {
@@ -81,12 +88,10 @@ impl super::App {
         let abs = path.canonicalize().unwrap_or(path);
         // Cursor.line is 0-based; DAP / the user-visible line number is 1-based.
         let line = self.cursor.line + 1;
-        let added = self.dap.toggle_breakpoint(&abs, line);
-        self.status_msg = if added {
-            format!("breakpoint set at {}:{}", abs.display(), line)
-        } else {
-            format!("breakpoint cleared at {}:{}", abs.display(), line)
-        };
+        // Toggle the breakpoint silently — the gutter dot is the
+        // user-visible confirmation, so a status-line notification is
+        // redundant noise on every press.
+        let _ = self.dap.toggle_breakpoint(&abs, line);
     }
 
     fn dap_clear_breakpoints_in_file(&mut self) {
@@ -147,6 +152,10 @@ impl super::App {
                 DapEvent::Terminated => {
                     self.status_msg = "debug: session ended".into();
                     self.dap.session = None;
+                    if self.debug_pane_open {
+                        self.debug_pane_open = false;
+                        self.adjust_viewport();
+                    }
                 }
                 DapEvent::AdapterError(msg) => {
                     self.status_msg = format!("debug error: {msg}");

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -113,6 +113,7 @@ impl super::App {
                     DebugAction::StepIn => DebugSubCmd::StepIn,
                     DebugAction::StepOut => DebugSubCmd::StepOut,
                     DebugAction::PaneToggle => DebugSubCmd::PaneToggle,
+                    DebugAction::FocusPane => DebugSubCmd::FocusPane,
                 };
                 self.dispatch_debug(sub);
             }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -100,6 +100,22 @@ impl super::App {
             Action::LspRename => self.start_rename_prompt(),
             Action::ReplaceAllInBuffer => self.start_replace_all_prompt(),
             Action::Format => self.format_active(),
+            Action::Debug(d) => {
+                use crate::command::DebugSubCmd;
+                use crate::parser::DebugAction;
+                let sub = match d {
+                    DebugAction::Start => DebugSubCmd::Start,
+                    DebugAction::Stop => DebugSubCmd::Stop,
+                    DebugAction::ToggleBreakpoint => DebugSubCmd::Break,
+                    DebugAction::ClearBreakpointsInFile => DebugSubCmd::ClearBreakpointsInFile,
+                    DebugAction::Continue => DebugSubCmd::Continue,
+                    DebugAction::Next => DebugSubCmd::Next,
+                    DebugAction::StepIn => DebugSubCmd::StepIn,
+                    DebugAction::StepOut => DebugSubCmd::StepOut,
+                    DebugAction::PaneToggle => DebugSubCmd::PaneToggle,
+                };
+                self.dispatch_debug(sub);
+            }
             Action::AddNextOccurrenceSelection => self.add_next_occurrence_selection(),
             Action::SurroundDelete { ch } => {
                 self.history.record(&self.buffer.rope, self.cursor);

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -99,6 +99,7 @@ impl super::App {
             Action::LspFindReferences => self.lsp_request_references(),
             Action::LspRename => self.start_rename_prompt(),
             Action::ReplaceAllInBuffer => self.start_replace_all_prompt(),
+            Action::Format => self.format_active(),
             Action::AddNextOccurrenceSelection => self.add_next_occurrence_selection(),
             Action::SurroundDelete { ch } => {
                 self.history.record(&self.buffer.rope, self.cursor);

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -787,6 +787,15 @@ impl super::App {
             }
             ExCommand::Format => self.format_active(),
             ExCommand::Health => self.cmd_health(),
+            ExCommand::DebugPaneToggle => {
+                self.debug_pane_open = !self.debug_pane_open;
+                self.adjust_viewport();
+                self.status_msg = if self.debug_pane_open {
+                    "Debug pane opened".into()
+                } else {
+                    "Debug pane closed".into()
+                };
+            }
             ExCommand::Goto(n) => {
                 let m = motion::goto_line(&self.buffer, n);
                 self.cursor = m.target;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -115,6 +115,9 @@ impl super::App {
                     Mode::Search { .. } => self.handle_search_key(k),
                     Mode::Picker => self.handle_picker_key(k),
                     Mode::Prompt(_) => self.handle_prompt_key(k),
+                    Mode::DebugPane => {
+                        self.handle_debug_pane_key(k);
+                    }
                 }
             }
             crossterm::event::Event::Mouse(me) => {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -98,7 +98,8 @@ impl super::App {
                 // `e` after `<space>`) is also allowed so multi-key shortcuts
                 // resolve normally.
                 let leader_pending = self.pending.awaiting_leader
-                    || self.pending.awaiting_buffer_leader;
+                    || self.pending.awaiting_buffer_leader
+                    || self.pending.awaiting_debug_leader;
                 if self.show_start_page
                     && matches!(self.mode, Mode::Normal)
                     && !leader_pending
@@ -353,7 +354,9 @@ impl super::App {
             ParseResult::Action(a) => self.apply_action(a),
         }
         // Track any prefix that's awaiting its next key — drives the which-key timer.
-        let prefix_active = self.pending.awaiting_leader || self.pending.awaiting_buffer_leader;
+        let prefix_active = self.pending.awaiting_leader
+            || self.pending.awaiting_buffer_leader
+            || self.pending.awaiting_debug_leader;
         if prefix_active {
             if self.leader_pressed_at.is_none() {
                 self.leader_pressed_at = Some(std::time::Instant::now());
@@ -787,15 +790,7 @@ impl super::App {
             }
             ExCommand::Format => self.format_active(),
             ExCommand::Health => self.cmd_health(),
-            ExCommand::DebugPaneToggle => {
-                self.debug_pane_open = !self.debug_pane_open;
-                self.adjust_viewport();
-                self.status_msg = if self.debug_pane_open {
-                    "Debug pane opened".into()
-                } else {
-                    "Debug pane closed".into()
-                };
-            }
+            ExCommand::Debug(sub) => self.dispatch_debug(sub),
             ExCommand::Goto(n) => {
                 let m = motion::goto_line(&self.buffer, n);
                 self.cursor = m.target;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -78,6 +78,12 @@ impl super::App {
                 }
                 self.hover = None;
                 self.whichkey = None;
+                // IDE-parity debug function keys — work regardless of mode
+                // so F10 / F11 / F5 behave the way the user's muscle
+                // memory expects coming from Visual Studio / Rider.
+                if self.try_handle_debug_function_key(&k) {
+                    return Ok(());
+                }
                 // Macro recording: stop on `q` in normal, otherwise capture every key.
                 if !self.replaying_macro && self.recording_macro.is_some() {
                     let stop = matches!(self.mode, Mode::Normal)

--- a/src/app/registers.rs
+++ b/src/app/registers.rs
@@ -50,6 +50,27 @@ impl super::App {
         if key == '_' {
             return None;
         }
+        // For the registers that mirror the OS clipboard, check the
+        // clipboard first — anything the user just copied in another
+        // app should win over our in-memory register, which would
+        // otherwise hold a stale in-editor yank from earlier.
+        if matches!(key, '"' | '+' | '*') {
+            if let Some(text) = get_system_clipboard() {
+                if !text.is_empty() {
+                    // Heuristic for linewise paste: a clipboard payload
+                    // whose final char is `\n` and which contains an
+                    // interior newline almost always came from a
+                    // line-oriented copy. Single-line content with a
+                    // trailing newline (e.g. terminal echo) stays
+                    // charwise so paste-at-cursor doesn't open a
+                    // surprise extra line.
+                    let trimmed_ends_nl = text.ends_with('\n');
+                    let has_interior_nl = text[..text.len().saturating_sub(1)].contains('\n');
+                    let linewise = trimmed_ends_nl && has_interior_nl;
+                    return Some(Register { text, linewise });
+                }
+            }
+        }
         self.registers.get(&key).cloned()
     }
 
@@ -165,4 +186,14 @@ pub fn set_system_clipboard(text: &str) {
     if let Ok(mut cb) = arboard::Clipboard::new() {
         let _ = cb.set_text(text.to_string());
     }
+}
+
+/// Best-effort read of the OS clipboard as UTF-8. Returns `None` when the
+/// clipboard is empty, the platform refuses access, or the contents aren't
+/// text (an image, a file list, etc.). Swallows every failure so a missing
+/// display server / locked clipboard / image payload just makes `p` fall
+/// back to the in-memory register instead of erroring out.
+pub fn get_system_clipboard() -> Option<String> {
+    let mut cb = arboard::Clipboard::new().ok()?;
+    cb.get_text().ok()
 }

--- a/src/app/registers.rs
+++ b/src/app/registers.rs
@@ -108,6 +108,9 @@ impl super::App {
                 Mode::Search { .. } => self.handle_search_key(k),
                 Mode::Picker => self.handle_picker_key(k),
                 Mode::Prompt(_) => self.handle_prompt_key(k),
+                // Macros don't navigate the debug pane — replay aborts if
+                // the user happened to start recording while focused there.
+                Mode::DebugPane => break,
             }
         }
         self.replaying_macro = false;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -170,6 +170,7 @@ pub fn leader_entries() -> Vec<(String, String)> {
         ("S".into(), "Workspace symbols".into()),
         ("a".into(), "Code actions".into()),
         ("r".into(), "Rename".into()),
+        ("f".into(), "Format".into()),
     ]
 }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -164,6 +164,7 @@ pub fn leader_entries() -> Vec<(String, String)> {
     vec![
         ("<space>".into(), "Files".into()),
         ("b".into(), "+Buffer".into()),
+        ("d".into(), "+Debug".into()),
         ("g".into(), "Grep".into()),
         ("e".into(), "Yazi".into()),
         ("o".into(), "Doc symbols".into()),
@@ -181,6 +182,20 @@ pub fn buffer_prefix_entries() -> Vec<(String, String)> {
         ("o".into(), "Only (close others)".into()),
         ("n".into(), "Next".into()),
         ("p".into(), "Prev".into()),
+    ]
+}
+
+pub fn debug_prefix_entries() -> Vec<(String, String)> {
+    vec![
+        ("s".into(), "Start session".into()),
+        ("S".into(), "Stop session".into()),
+        ("b".into(), "Toggle breakpoint".into()),
+        ("B".into(), "Clear breakpoints (file)".into()),
+        ("c".into(), "Continue".into()),
+        ("n".into(), "Step over".into()),
+        ("i".into(), "Step into".into()),
+        ("o".into(), "Step out".into()),
+        ("p".into(), "Toggle pane".into()),
     ]
 }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -194,6 +194,7 @@ pub fn debug_prefix_entries() -> Vec<(String, String)> {
         ("i".into(), "Step into".into()),
         ("O".into(), "Step out".into()),
         ("p".into(), "Toggle pane".into()),
+        ("f".into(), "Focus pane".into()),
         ("o".into(), "Doc symbols".into()),
         ("S".into(), "Workspace symbols".into()),
     ]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -167,8 +167,6 @@ pub fn leader_entries() -> Vec<(String, String)> {
         ("d".into(), "+Debug".into()),
         ("g".into(), "Grep".into()),
         ("e".into(), "Yazi".into()),
-        ("o".into(), "Doc symbols".into()),
-        ("S".into(), "Workspace symbols".into()),
         ("a".into(), "Code actions".into()),
         ("r".into(), "Rename".into()),
         ("f".into(), "Format".into()),
@@ -188,14 +186,16 @@ pub fn buffer_prefix_entries() -> Vec<(String, String)> {
 pub fn debug_prefix_entries() -> Vec<(String, String)> {
     vec![
         ("s".into(), "Start session".into()),
-        ("S".into(), "Stop session".into()),
+        ("q".into(), "Stop session".into()),
         ("b".into(), "Toggle breakpoint".into()),
         ("B".into(), "Clear breakpoints (file)".into()),
         ("c".into(), "Continue".into()),
         ("n".into(), "Step over".into()),
         ("i".into(), "Step into".into()),
-        ("o".into(), "Step out".into()),
+        ("O".into(), "Step out".into()),
         ("p".into(), "Toggle pane".into()),
+        ("o".into(), "Doc symbols".into()),
+        ("S".into(), "Workspace symbols".into()),
     ]
 }
 

--- a/src/app/view.rs
+++ b/src/app/view.rs
@@ -238,11 +238,41 @@ impl super::App {
     }
 
     pub fn buffer_rows(&self) -> usize {
-        // Reserve the status line at the bottom and (when applicable) one
-        // row at the top for the tab bar.
+        // Reserve the status line at the bottom, (when applicable) one row at
+        // the top for the tab bar, and the debug pane rows at the bottom when
+        // a debug session is up or the pane is pinned open.
         (self.height as usize)
             .saturating_sub(1)
             .saturating_sub(self.buffer_top())
+            .saturating_sub(self.debug_pane_rows())
+    }
+
+    /// Number of rows the bottom debug pane occupies. Zero when the pane is
+    /// closed or when the terminal is too short to hold it without squashing
+    /// the editor below a usable threshold — opening the pane on a tiny
+    /// terminal silently becomes a no-op rather than corrupting the layout.
+    pub fn debug_pane_rows(&self) -> usize {
+        if !self.debug_pane_open {
+            return 0;
+        }
+        let h = self.height as usize;
+        let chrome = self.buffer_top() + 1;
+        let avail = h.saturating_sub(chrome);
+        if avail < 10 {
+            return 0;
+        }
+        let target = (h / 3).clamp(8, 20);
+        target.min(avail.saturating_sub(6))
+    }
+
+    /// First terminal row occupied by the debug pane. Sits directly above the
+    /// status line. Caller must check `debug_pane_rows() > 0` first — when the
+    /// pane is closed this returns the status-line row, which is not a valid
+    /// drawing target.
+    pub fn debug_pane_top(&self) -> usize {
+        (self.height as usize)
+            .saturating_sub(1)
+            .saturating_sub(self.debug_pane_rows())
     }
 
     /// True when the tab bar should be painted. Shown whenever any

--- a/src/command.rs
+++ b/src/command.rs
@@ -22,6 +22,7 @@ pub enum ExCommand {
     NoHighlight,
     Format,
     Health,
+    DebugPaneToggle,
     Unknown(String),
 }
 
@@ -99,6 +100,7 @@ pub fn parse(line: &str) -> ExCommand {
         "noh" | "nohlsearch" => ExCommand::NoHighlight,
         "fmt" | "format" => ExCommand::Format,
         "health" | "checkhealth" => ExCommand::Health,
+        "dappane" => ExCommand::DebugPaneToggle,
         _ => ExCommand::Unknown(line.to_string()),
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -41,6 +41,7 @@ pub enum DebugSubCmd {
     StepIn,
     StepOut,
     PaneToggle,
+    FocusPane,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/command.rs
+++ b/src/command.rs
@@ -22,8 +22,25 @@ pub enum ExCommand {
     NoHighlight,
     Format,
     Health,
-    DebugPaneToggle,
+    Debug(DebugSubCmd),
     Unknown(String),
+}
+
+/// Debugger sub-commands accessible via `:debug`, `:dapstop`, `:dapbreak`,
+/// `:dapc`, etc. Grouped into one variant so the dispatch in `input.rs`
+/// has a single arm and the parser stays compact.
+#[derive(Debug, Clone, Copy)]
+pub enum DebugSubCmd {
+    Start,
+    Stop,
+    Break,
+    /// Clear every breakpoint in the active buffer.
+    ClearBreakpointsInFile,
+    Continue,
+    Next,
+    StepIn,
+    StepOut,
+    PaneToggle,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -100,7 +117,15 @@ pub fn parse(line: &str) -> ExCommand {
         "noh" | "nohlsearch" => ExCommand::NoHighlight,
         "fmt" | "format" => ExCommand::Format,
         "health" | "checkhealth" => ExCommand::Health,
-        "dappane" => ExCommand::DebugPaneToggle,
+        "debug" | "dap" => ExCommand::Debug(DebugSubCmd::Start),
+        "dapstop" => ExCommand::Debug(DebugSubCmd::Stop),
+        "dapbreak" | "dapb" => ExCommand::Debug(DebugSubCmd::Break),
+        "dapclear" => ExCommand::Debug(DebugSubCmd::ClearBreakpointsInFile),
+        "dapcontinue" | "dapc" => ExCommand::Debug(DebugSubCmd::Continue),
+        "dapnext" | "dapn" => ExCommand::Debug(DebugSubCmd::Next),
+        "dapin" | "dapi" => ExCommand::Debug(DebugSubCmd::StepIn),
+        "dapout" | "dapo" => ExCommand::Debug(DebugSubCmd::StepOut),
+        "dappane" => ExCommand::Debug(DebugSubCmd::PaneToggle),
         _ => ExCommand::Unknown(line.to_string()),
     }
 }

--- a/src/dap.rs
+++ b/src/dap.rs
@@ -15,11 +15,13 @@
 //! the `client` and `io` submodules that actually spawn the adapter and
 //! drive the protocol.
 
+mod client;
+mod io;
 mod manager;
 mod specs;
 mod types;
 
-pub use manager::DapManager;
+pub use manager::{DapManager, StepKind};
 #[allow(unused_imports)]
 pub use specs::{adapter_for_workspace, DapAdapterSpec, PrelaunchCommand};
 #[allow(unused_imports)]

--- a/src/dap.rs
+++ b/src/dap.rs
@@ -21,7 +21,7 @@ mod manager;
 mod specs;
 mod types;
 
-pub use manager::{DapManager, StepKind};
+pub use manager::{flat_locals_view, DapManager, StepKind};
 #[allow(unused_imports)]
 pub use specs::{adapter_for_workspace, DapAdapterSpec, PrelaunchCommand};
 #[allow(unused_imports)]

--- a/src/dap.rs
+++ b/src/dap.rs
@@ -1,0 +1,29 @@
+//! Debug Adapter Protocol client. Spawns an external adapter (e.g.
+//! `netcoredbg --interpreter=vscode`), drives the initialize/launch/
+//! configurationDone handshake, and routes events into the editor's main
+//! loop the same way the LSP layer does. Adapter-agnostic — the registry
+//! in `specs.rs` is the only place that knows about specific debuggers.
+//!
+//! Sub-module map:
+//! - [`types`]: wire-side data types — `DapIncoming`, `DapEvent`,
+//!   breakpoint / frame / variable structs
+//! - [`specs`]: adapter registry, workspace-root discovery, `$PATH` lookup
+//! - [`manager`]: `DapManager` — owns the active session, the user's
+//!   breakpoint table, and the receiver side of the reader-thread channel
+//!
+//! Phase 1 ships types + registry + an inert `DapManager`. Phase 2 adds
+//! the `client` and `io` submodules that actually spawn the adapter and
+//! drive the protocol.
+
+mod manager;
+mod specs;
+mod types;
+
+pub use manager::DapManager;
+#[allow(unused_imports)]
+pub use specs::{adapter_for_workspace, DapAdapterSpec, PrelaunchCommand};
+#[allow(unused_imports)]
+pub use types::{
+    Breakpoint, DapEvent, DapIncoming, OutputLine, Scope, SessionState, SourceBreakpoint,
+    StackFrame, Variable,
+};

--- a/src/dap/client.rs
+++ b/src/dap/client.rs
@@ -6,30 +6,34 @@
 
 use anyhow::Result;
 use serde_json::{json, Value};
-use std::io::Write;
-use std::process::{Child, ChildStdin, Command, Stdio};
-use std::sync::mpsc::{channel, Receiver};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStderr, Command, Stdio};
+use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
 use super::io::reader_loop;
 use super::specs::{resolve_command, DapAdapterSpec};
-use super::types::DapIncoming;
+use super::types::{DapIncoming, OutputLine};
 
 pub struct DapClient {
     #[allow(dead_code)]
     pub adapter_key: String,
-    _child: Child,
+    child: Arc<Mutex<Child>>,
     stdin: Arc<Mutex<ChildStdin>>,
     pub incoming_rx: Receiver<DapIncoming>,
+    /// Adapter stderr — populated by a side thread that pushes each line
+    /// into the channel as a synthetic `output` event. Lets the user see
+    /// adapter crashes that would otherwise look like a silent hang.
+    pub stderr_rx: Receiver<OutputLine>,
     next_seq: Arc<Mutex<u64>>,
 }
 
 impl DapClient {
-    /// Spawn the adapter described by `spec`. The reader thread starts
-    /// immediately and pushes parsed messages onto the returned receiver.
-    /// Returns `None` if the adapter command can't be resolved on `$PATH`
-    /// or the spawn itself fails.
+    /// Spawn the adapter described by `spec`. Two reader threads start
+    /// immediately: one parses framed DAP messages off stdout, the other
+    /// drains stderr into a synthetic output channel so adapter crashes
+    /// surface to the pane instead of disappearing.
     pub fn spawn_spec(spec: &DapAdapterSpec) -> Option<Self> {
         let cmd_path = resolve_command(spec.cmd_candidates)?;
         let mut command = Command::new(&cmd_path);
@@ -39,24 +43,42 @@ impl DapClient {
         let mut child = command
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .spawn()
             .ok()?;
         let stdin = Arc::new(Mutex::new(child.stdin.take()?));
         let stdout = child.stdout.take()?;
+        let stderr = child.stderr.take()?;
 
         let (tx, rx) = channel();
         thread::spawn(move || {
             reader_loop(stdout, tx);
         });
 
+        let (stderr_tx, stderr_rx) = channel();
+        thread::spawn(move || {
+            stderr_loop(stderr, stderr_tx);
+        });
+
         Some(Self {
             adapter_key: spec.key.to_string(),
-            _child: child,
+            child: Arc::new(Mutex::new(child)),
             stdin,
             incoming_rx: rx,
+            stderr_rx,
             next_seq: Arc::new(Mutex::new(1)),
         })
+    }
+
+    /// Has the adapter process exited? Non-blocking — `Some(code)` once
+    /// the child reaps, `None` while it's still alive. The manager polls
+    /// this on `drain` so a silent crash becomes an `AdapterError` event.
+    pub fn try_exit_status(&self) -> Option<i32> {
+        let mut child = self.child.lock().ok()?;
+        match child.try_wait() {
+            Ok(Some(status)) => Some(status.code().unwrap_or(-1)),
+            _ => None,
+        }
     }
 
     pub fn alloc_seq(&self) -> u64 {
@@ -107,5 +129,23 @@ impl DapClient {
         stdin.write_all(frame.as_bytes())?;
         stdin.flush()?;
         Ok(())
+    }
+}
+
+/// Forward each line of the adapter's stderr to the editor as a synthetic
+/// "stderr"-category output line. Without this, crashes that print a stack
+/// trace and exit immediately look identical to "adapter is alive but not
+/// answering" — i.e. an indistinguishable hang.
+fn stderr_loop(stderr: ChildStderr, tx: Sender<OutputLine>) {
+    let reader = BufReader::new(stderr);
+    for line in reader.lines() {
+        let Ok(text) = line else { break };
+        if text.is_empty() {
+            continue;
+        }
+        let _ = tx.send(OutputLine {
+            category: "stderr".into(),
+            output: text,
+        });
     }
 }

--- a/src/dap/client.rs
+++ b/src/dap/client.rs
@@ -1,0 +1,111 @@
+//! `DapClient` — one spawned debug adapter. Owns the child process, the
+//! stdin handle, and a receiver for the reader-thread channel. Doesn't
+//! understand DAP semantics — those live in `manager.rs`. Mirrors
+//! `lsp/client.rs` but the message shapes use DAP's `seq` / `type` /
+//! `command` fields instead of JSON-RPC's `id` / `method`.
+
+use anyhow::Result;
+use serde_json::{json, Value};
+use std::io::Write;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{channel, Receiver};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use super::io::reader_loop;
+use super::specs::{resolve_command, DapAdapterSpec};
+use super::types::DapIncoming;
+
+pub struct DapClient {
+    #[allow(dead_code)]
+    pub adapter_key: String,
+    _child: Child,
+    stdin: Arc<Mutex<ChildStdin>>,
+    pub incoming_rx: Receiver<DapIncoming>,
+    next_seq: Arc<Mutex<u64>>,
+}
+
+impl DapClient {
+    /// Spawn the adapter described by `spec`. The reader thread starts
+    /// immediately and pushes parsed messages onto the returned receiver.
+    /// Returns `None` if the adapter command can't be resolved on `$PATH`
+    /// or the spawn itself fails.
+    pub fn spawn_spec(spec: &DapAdapterSpec) -> Option<Self> {
+        let cmd_path = resolve_command(spec.cmd_candidates)?;
+        let mut command = Command::new(&cmd_path);
+        for arg in spec.args {
+            command.arg(arg);
+        }
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+        let stdin = Arc::new(Mutex::new(child.stdin.take()?));
+        let stdout = child.stdout.take()?;
+
+        let (tx, rx) = channel();
+        thread::spawn(move || {
+            reader_loop(stdout, tx);
+        });
+
+        Some(Self {
+            adapter_key: spec.key.to_string(),
+            _child: child,
+            stdin,
+            incoming_rx: rx,
+            next_seq: Arc::new(Mutex::new(1)),
+        })
+    }
+
+    pub fn alloc_seq(&self) -> u64 {
+        let mut g = self.next_seq.lock().unwrap();
+        let id = *g;
+        *g += 1;
+        id
+    }
+
+    /// Send a `request` message. `seq` should come from `alloc_seq` so
+    /// responses can be matched against it.
+    pub fn send_request(&self, seq: u64, command: &str, arguments: Value) -> Result<()> {
+        let msg = json!({
+            "seq": seq,
+            "type": "request",
+            "command": command,
+            "arguments": arguments,
+        });
+        self.write_frame(&msg)
+    }
+
+    /// Reply to a server-initiated request. The manager bounces
+    /// `runInTerminal`-style requests through the main thread (for parity
+    /// with how the LSP layer treats `workspace/applyEdit`).
+    #[allow(dead_code)]
+    pub fn send_response(
+        &self,
+        request_seq: u64,
+        command: &str,
+        success: bool,
+        body: Value,
+    ) -> Result<()> {
+        let msg = json!({
+            "seq": self.alloc_seq(),
+            "type": "response",
+            "request_seq": request_seq,
+            "success": success,
+            "command": command,
+            "body": body,
+        });
+        self.write_frame(&msg)
+    }
+
+    fn write_frame(&self, msg: &Value) -> Result<()> {
+        let body = serde_json::to_string(msg)?;
+        let frame = format!("Content-Length: {}\r\n\r\n{}", body.len(), body);
+        let mut stdin = self.stdin.lock().unwrap();
+        stdin.write_all(frame.as_bytes())?;
+        stdin.flush()?;
+        Ok(())
+    }
+}

--- a/src/dap/io.rs
+++ b/src/dap/io.rs
@@ -1,0 +1,98 @@
+//! Reader-thread loop for one DAP adapter. Consumes Content-Length framed
+//! JSON off the adapter's stdout, classifies each message as event /
+//! response / request, and forwards it on the channel. The manager (main
+//! thread) does the protocol bookkeeping.
+//!
+//! The framing is identical to LSP — same `Content-Length: N\r\n\r\n`
+//! header, same JSON body — so this file's framing code mirrors
+//! `lsp/io.rs` line-for-line. Only the dispatch differs.
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Read};
+use std::sync::mpsc::Sender;
+
+use super::types::DapIncoming;
+
+pub(super) fn reader_loop(stdout: impl Read + Send + 'static, tx: Sender<DapIncoming>) {
+    let mut reader = BufReader::new(stdout);
+    loop {
+        let mut content_length: Option<usize> = None;
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).is_err() || line.is_empty() {
+                return;
+            }
+            let trimmed = line.trim_end_matches(&['\r', '\n'][..]);
+            if trimmed.is_empty() {
+                break;
+            }
+            if let Some(rest) = trimmed.to_lowercase().strip_prefix("content-length:") {
+                content_length = rest.trim().parse().ok();
+            }
+        }
+        let Some(len) = content_length else { return };
+        let mut body = vec![0u8; len];
+        if reader.read_exact(&mut body).is_err() {
+            return;
+        }
+        let Ok(value) = serde_json::from_slice::<Value>(&body) else { continue };
+        dispatch(value, &tx);
+    }
+}
+
+fn dispatch(msg: Value, tx: &Sender<DapIncoming>) {
+    let msg_type = msg.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    match msg_type {
+        "event" => {
+            let event = msg
+                .get("event")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let body = msg.get("body").cloned().unwrap_or(Value::Null);
+            let _ = tx.send(DapIncoming::Event { event, body });
+        }
+        "response" => {
+            let request_seq = msg
+                .get("request_seq")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let command = msg
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let success = msg
+                .get("success")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let body = msg.get("body").cloned().unwrap_or(Value::Null);
+            let message = msg
+                .get("message")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let _ = tx.send(DapIncoming::Response {
+                request_seq,
+                command,
+                success,
+                body,
+                message,
+            });
+        }
+        "request" => {
+            let seq = msg.get("seq").and_then(|v| v.as_u64()).unwrap_or(0);
+            let command = msg
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let arguments = msg.get("arguments").cloned().unwrap_or(Value::Null);
+            let _ = tx.send(DapIncoming::Request {
+                seq,
+                command,
+                arguments,
+            });
+        }
+        _ => {}
+    }
+}

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -304,9 +304,18 @@ impl DapManager {
     }
 
     /// Pull all available messages off the reader-thread channel, run them
-    /// through the protocol state machine, and return the editor-facing
-    /// `DapEvent`s the main loop should react to.
-    pub fn drain(&mut self) -> Vec<DapEvent> {
+    /// through the protocol state machine, and return:
+    ///
+    /// - the editor-facing `DapEvent`s the main loop should react to, and
+    /// - a `progress` bool that's `true` whenever *any* incoming message
+    ///   was processed.
+    ///
+    /// Many protocol replies (stackTrace, scopes, variables) update visible
+    /// session state without emitting a user-facing event — the renderer
+    /// still needs to know they happened, otherwise frames + locals
+    /// appear stale until the next keypress. The `progress` flag lets the
+    /// main loop request a redraw on those silent state mutations.
+    pub fn drain(&mut self) -> (Vec<DapEvent>, bool) {
         let mut events = Vec::new();
         let mut msgs = Vec::new();
         let mut stderr_lines: Vec<OutputLine> = Vec::new();
@@ -323,6 +332,7 @@ impl DapManager {
             // the crash so the user sees something instead of a hang.
             exit_code = session.client.try_exit_status();
         }
+        let progress = !msgs.is_empty() || !stderr_lines.is_empty() || exit_code.is_some();
         for line in stderr_lines {
             // Stream into the output buffer so the pane shows whatever the
             // adapter printed before dying.
@@ -355,7 +365,7 @@ impl DapManager {
                 events.push(DapEvent::Terminated);
             }
         }
-        events
+        (events, progress)
     }
 
     fn process_incoming(&mut self, msg: DapIncoming, events: &mut Vec<DapEvent>) {
@@ -959,7 +969,9 @@ mod tests {
     fn idle_manager_is_inactive_and_drains_empty() {
         let mut m = DapManager::new();
         assert!(!m.is_active());
-        assert!(m.drain().is_empty());
+        let (events, progress) = m.drain();
+        assert!(events.is_empty());
+        assert!(!progress);
     }
 
     #[test]

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -1,12 +1,18 @@
 //! `DapManager` owns at most one debug session plus the user's breakpoint
-//! table. Phase 1: just the data shell + breakpoint mutators — no session
-//! lifecycle yet. The Phase 2 work adds spawn / handshake / step / variable
-//! fetch driven by an internal `DapClient` and reader-thread channel.
+//! table. Drives the adapter's lifecycle (initialize → launch → set
+//! breakpoints → configurationDone → run/stop) in response to messages
+//! arriving on the reader-thread channel; the main loop calls `drain` to
+//! pull the resulting `DapEvent`s off and react.
 
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use super::types::{DapEvent, OutputLine, SessionState, SourceBreakpoint, StackFrame};
+use super::client::DapClient;
+use super::specs::DapAdapterSpec;
+use super::types::{
+    DapEvent, DapIncoming, OutputLine, SessionState, SourceBreakpoint, StackFrame,
+};
 
 #[derive(Default)]
 #[allow(dead_code)]
@@ -17,23 +23,40 @@ pub struct DapManager {
     pub breakpoints: HashMap<PathBuf, Vec<SourceBreakpoint>>,
     /// Active session, if any. `None` between launches.
     pub session: Option<DapSession>,
-    /// Backlog of debug-console output captured before the panel was opened
-    /// or while no UI was rendering. Drained by the renderer.
+    /// Rolling debug-console log. Newest at the tail. Bounded so a chatty
+    /// program doesn't grow it without limit.
     pub output_buffer: Vec<OutputLine>,
 }
 
+const OUTPUT_LOG_CAP: usize = 2000;
+
 #[allow(dead_code)]
 pub struct DapSession {
-    /// Adapter spec key — `"dotnet"`, `"go"`, … — for status display.
     pub adapter_key: String,
-    /// Workspace root the session was launched against.
     pub workspace_root: PathBuf,
-    /// Current high-level state.
     pub state: SessionState,
-    /// Call stack of the currently-stopped thread, if any.
     pub frames: Vec<StackFrame>,
-    /// Stopped thread id, if a `stopped` event has been received.
     pub current_thread: Option<u64>,
+    /// Spawned adapter process + reader channel. Dropping the session
+    /// drops the child, which closes the reader thread on its own.
+    pub client: DapClient,
+    /// Launch-request arguments. Built before spawn and held so they can
+    /// be sent the moment the `initialize` response arrives, without
+    /// re-running adapter-specific resolution.
+    pub launch_args: Value,
+    /// Last status message emitted by the adapter (or our own status
+    /// machine) — surfaced verbatim in the bottom pane header.
+    pub status_line: String,
+}
+
+/// What `step()` should ask the adapter to do.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub enum StepKind {
+    Continue,
+    Next,
+    StepIn,
+    StepOut,
 }
 
 impl DapManager {
@@ -41,10 +64,6 @@ impl DapManager {
         Self::default()
     }
 
-    /// True when there is a session attempting to drive (or driving) a
-    /// debuggee. Used by the renderer to decide whether to show the
-    /// placeholder text or the real panes.
-    #[allow(dead_code)]
     pub fn is_active(&self) -> bool {
         self.session
             .as_ref()
@@ -52,12 +71,9 @@ impl DapManager {
             .unwrap_or(false)
     }
 
-    /// Toggle a line breakpoint. Returns the new state (`true` if the
-    /// breakpoint now exists, `false` if it was removed).
-    #[allow(dead_code)]
     pub fn toggle_breakpoint(&mut self, path: &Path, line: usize) -> bool {
         let entry = self.breakpoints.entry(path.to_path_buf()).or_default();
-        if let Some(idx) = entry.iter().position(|b| b.line == line) {
+        let added = if let Some(idx) = entry.iter().position(|b| b.line == line) {
             entry.remove(idx);
             if entry.is_empty() {
                 self.breakpoints.remove(path);
@@ -69,12 +85,28 @@ impl DapManager {
                 condition: None,
             });
             true
-        }
+        };
+        // If a session is alive, push the updated source-level list right
+        // away so the dot the user just toggled in the gutter takes effect.
+        self.resend_breakpoints_for(path);
+        added
     }
 
-    /// True when `path` has a user-set breakpoint at `line`. Renderer-side
-    /// gutter marker uses this.
-    #[allow(dead_code)]
+    /// Drop every breakpoint we know about for `path` and push the empty
+    /// list to the adapter if a session is alive. Returns the number of
+    /// breakpoints that were cleared so the caller can surface it.
+    pub fn clear_breakpoints_in_file(&mut self, path: &Path) -> usize {
+        let removed = self
+            .breakpoints
+            .remove(path)
+            .map(|v| v.len())
+            .unwrap_or(0);
+        if removed > 0 {
+            self.resend_breakpoints_for(path);
+        }
+        removed
+    }
+
     pub fn has_breakpoint(&self, path: &Path, line: usize) -> bool {
         self.breakpoints
             .get(path)
@@ -82,12 +114,417 @@ impl DapManager {
             .unwrap_or(false)
     }
 
-    /// Phase-1 placeholder. The real implementation drains the reader-thread
-    /// channel and translates raw `DapIncoming`s into `DapEvent`s.
-    #[allow(dead_code)]
-    pub fn drain(&mut self) -> Vec<DapEvent> {
-        Vec::new()
+    /// Spawn the adapter, run its prelaunch hook (synchronous — typically
+    /// 1-2s for `dotnet build`), and send the initial `initialize` request.
+    /// The rest of the handshake is driven by responses + events arriving
+    /// on the channel, which `drain` processes.
+    pub fn start_session(
+        &mut self,
+        adapter: DapAdapterSpec,
+        root: PathBuf,
+    ) -> Result<(), String> {
+        if self.is_active() {
+            return Err("debug session already active — :dapstop first".into());
+        }
+
+        if let Some(pre) = adapter.prelaunch {
+            let output = std::process::Command::new(pre.program)
+                .args(pre.args)
+                .current_dir(&root)
+                .output()
+                .map_err(|e| format!("{} failed to start: {}", pre.program, e))?;
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let detail = stderr
+                    .lines()
+                    .rev()
+                    .find(|l| !l.trim().is_empty())
+                    .or_else(|| stdout.lines().rev().find(|l| !l.trim().is_empty()))
+                    .unwrap_or("(no output)");
+                return Err(format!("{}: {}", pre.label, detail));
+            }
+        }
+
+        // Resolve launch args before spawning the adapter — if the dll
+        // can't be found we avoid leaking an orphan netcoredbg process.
+        let launch_args = (adapter.build_launch_args)(&root)?;
+
+        let client = DapClient::spawn_spec(&adapter)
+            .ok_or_else(|| format!("could not spawn adapter `{}`", adapter.key))?;
+
+        let init_seq = client.alloc_seq();
+        client
+            .send_request(
+                init_seq,
+                "initialize",
+                json!({
+                    "clientID": "binvim",
+                    "clientName": "binvim",
+                    "adapterID": adapter.key,
+                    "pathFormat": "path",
+                    "linesStartAt1": true,
+                    "columnsStartAt1": true,
+                    "supportsVariableType": true,
+                    "supportsVariablePaging": false,
+                    "supportsRunInTerminalRequest": false,
+                }),
+            )
+            .map_err(|e| format!("initialize send failed: {e}"))?;
+
+        self.session = Some(DapSession {
+            adapter_key: adapter.key.to_string(),
+            workspace_root: root,
+            state: SessionState::Initializing,
+            frames: Vec::new(),
+            current_thread: None,
+            client,
+            launch_args,
+            status_line: "initialising adapter…".into(),
+        });
+        Ok(())
     }
+
+    /// Politely ask the adapter to disconnect; clear local session state.
+    /// Best-effort — we drop the client immediately so any in-flight reply
+    /// gets discarded.
+    pub fn stop_session(&mut self) {
+        if let Some(session) = self.session.as_ref() {
+            let seq = session.client.alloc_seq();
+            let _ = session.client.send_request(
+                seq,
+                "disconnect",
+                json!({
+                    "restart": false,
+                    "terminateDebuggee": true,
+                }),
+            );
+        }
+        self.session = None;
+    }
+
+    /// One step / continue command targeted at the currently-stopped
+    /// thread. Silently does nothing if the session isn't in a stopped
+    /// state — the calling key/command handler decides whether to warn.
+    pub fn step(&self, kind: StepKind) {
+        let Some(session) = self.session.as_ref() else {
+            return;
+        };
+        let SessionState::Stopped { thread_id, .. } = session.state else {
+            return;
+        };
+        let (command, arguments) = match kind {
+            StepKind::Continue => ("continue", json!({ "threadId": thread_id })),
+            StepKind::Next => ("next", json!({ "threadId": thread_id })),
+            StepKind::StepIn => ("stepIn", json!({ "threadId": thread_id })),
+            StepKind::StepOut => ("stepOut", json!({ "threadId": thread_id })),
+        };
+        let seq = session.client.alloc_seq();
+        let _ = session.client.send_request(seq, command, arguments);
+    }
+
+    /// Pull all available messages off the reader-thread channel, run them
+    /// through the protocol state machine, and return the editor-facing
+    /// `DapEvent`s the main loop should react to.
+    pub fn drain(&mut self) -> Vec<DapEvent> {
+        let mut events = Vec::new();
+        let mut msgs = Vec::new();
+        if let Some(session) = self.session.as_ref() {
+            while let Ok(msg) = session.client.incoming_rx.try_recv() {
+                msgs.push(msg);
+            }
+        }
+        for msg in msgs {
+            self.process_incoming(msg, &mut events);
+        }
+        events
+    }
+
+    fn process_incoming(&mut self, msg: DapIncoming, events: &mut Vec<DapEvent>) {
+        match msg {
+            DapIncoming::Response {
+                command,
+                success,
+                body,
+                message,
+                ..
+            } => self.handle_response(command, success, body, message, events),
+            DapIncoming::Event { event, body } => self.handle_event(event, body, events),
+            DapIncoming::Request {
+                seq, command, ..
+            } => {
+                // We don't support any server-to-client requests yet; reply
+                // unsuccessfully so the adapter doesn't sit waiting.
+                if let Some(session) = self.session.as_ref() {
+                    let _ = session
+                        .client
+                        .send_response(seq, &command, false, Value::Null);
+                }
+            }
+        }
+    }
+
+    fn handle_response(
+        &mut self,
+        command: String,
+        success: bool,
+        body: Value,
+        message: Option<String>,
+        events: &mut Vec<DapEvent>,
+    ) {
+        if !success {
+            let detail = message.unwrap_or_else(|| "(no message)".into());
+            let err = format!("{} failed: {}", command, detail);
+            if let Some(s) = self.session.as_mut() {
+                s.status_line = err.clone();
+            }
+            events.push(DapEvent::AdapterError(err));
+            return;
+        }
+        match command.as_str() {
+            "initialize" => {
+                events.push(DapEvent::Initialized);
+                if let Some(session) = self.session.as_mut() {
+                    session.status_line = "launching debuggee…".into();
+                }
+                if let Some(session) = self.session.as_ref() {
+                    let seq = session.client.alloc_seq();
+                    let _ = session.client.send_request(
+                        seq,
+                        "launch",
+                        session.launch_args.clone(),
+                    );
+                }
+            }
+            "launch" => {
+                if let Some(s) = self.session.as_mut() {
+                    s.state = SessionState::Configuring;
+                }
+            }
+            "configurationDone" => {
+                if let Some(s) = self.session.as_mut() {
+                    s.state = SessionState::Running;
+                    s.status_line = "running".into();
+                }
+            }
+            "stackTrace" => {
+                let frames = parse_stack_frames(&body);
+                if let Some(s) = self.session.as_mut() {
+                    s.frames = frames;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_event(&mut self, event: String, body: Value, events: &mut Vec<DapEvent>) {
+        match event.as_str() {
+            "initialized" => {
+                self.send_breakpoints_and_configdone();
+            }
+            "stopped" => {
+                let thread_id = body
+                    .get("threadId")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let reason = body
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let description = body
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let hit_breakpoint_ids: Vec<u64> = body
+                    .get("hitBreakpointIds")
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.iter().filter_map(|v| v.as_u64()).collect())
+                    .unwrap_or_default();
+                if let Some(s) = self.session.as_mut() {
+                    s.state = SessionState::Stopped {
+                        thread_id,
+                        reason: reason.clone(),
+                    };
+                    s.current_thread = Some(thread_id);
+                    s.status_line = format!("stopped — {}", reason);
+                }
+                // Kick off a stackTrace request so the pane has frames to
+                // show as soon as the user reads the "stopped" status.
+                if let Some(session) = self.session.as_ref() {
+                    let seq = session.client.alloc_seq();
+                    let _ = session.client.send_request(
+                        seq,
+                        "stackTrace",
+                        json!({
+                            "threadId": thread_id,
+                            "startFrame": 0,
+                            "levels": 20,
+                        }),
+                    );
+                }
+                events.push(DapEvent::Stopped {
+                    thread_id,
+                    reason,
+                    description,
+                    hit_breakpoint_ids,
+                });
+            }
+            "continued" => {
+                let thread_id = body.get("threadId").and_then(|v| v.as_u64());
+                let all_threads = body
+                    .get("allThreadsContinued")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                if let Some(s) = self.session.as_mut() {
+                    s.frames.clear();
+                    s.current_thread = None;
+                    if !matches!(s.state, SessionState::Terminated) {
+                        s.state = SessionState::Running;
+                        s.status_line = "running".into();
+                    }
+                }
+                events.push(DapEvent::Continued {
+                    thread_id,
+                    all_threads,
+                });
+            }
+            "output" => {
+                let category = body
+                    .get("category")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("console")
+                    .to_string();
+                let output = body
+                    .get("output")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let line = OutputLine { category, output };
+                self.output_buffer.push(line.clone());
+                if self.output_buffer.len() > OUTPUT_LOG_CAP {
+                    let excess = self.output_buffer.len() - OUTPUT_LOG_CAP;
+                    self.output_buffer.drain(0..excess);
+                }
+                events.push(DapEvent::Output(line));
+            }
+            "terminated" => {
+                if let Some(s) = self.session.as_mut() {
+                    s.state = SessionState::Terminated;
+                    s.status_line = "terminated".into();
+                }
+                events.push(DapEvent::Terminated);
+            }
+            "exited" => {
+                let code = body.get("exitCode").and_then(|v| v.as_i64()).unwrap_or(0);
+                if let Some(s) = self.session.as_mut() {
+                    s.status_line = format!("exited ({})", code);
+                }
+                events.push(DapEvent::Exited { exit_code: code });
+            }
+            "thread" => {
+                let thread_id = body
+                    .get("threadId")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                let reason = body
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                events.push(DapEvent::Thread { reason, thread_id });
+            }
+            _ => {}
+        }
+    }
+
+    fn send_breakpoints_and_configdone(&self) {
+        let Some(session) = self.session.as_ref() else {
+            return;
+        };
+        // setBreakpoints replaces the adapter's per-source list — one
+        // request per file. Empty list is fine: a no-breakpoints source
+        // doesn't need a request, but sending it is harmless.
+        for (path, list) in &self.breakpoints {
+            let seq = session.client.alloc_seq();
+            let bps_json: Vec<Value> = list
+                .iter()
+                .map(|b| {
+                    let mut o = serde_json::Map::new();
+                    o.insert("line".into(), json!(b.line));
+                    if let Some(c) = &b.condition {
+                        o.insert("condition".into(), json!(c));
+                    }
+                    Value::Object(o)
+                })
+                .collect();
+            let _ = session.client.send_request(
+                seq,
+                "setBreakpoints",
+                json!({
+                    "source": { "path": path.display().to_string() },
+                    "breakpoints": bps_json,
+                }),
+            );
+        }
+        let seq = session.client.alloc_seq();
+        let _ = session
+            .client
+            .send_request(seq, "configurationDone", json!({}));
+    }
+
+    fn resend_breakpoints_for(&self, path: &Path) {
+        let Some(session) = self.session.as_ref() else {
+            return;
+        };
+        if matches!(session.state, SessionState::Terminated) {
+            return;
+        }
+        let list = self.breakpoints.get(path).cloned().unwrap_or_default();
+        let bps_json: Vec<Value> = list
+            .iter()
+            .map(|b| json!({ "line": b.line }))
+            .collect();
+        let seq = session.client.alloc_seq();
+        let _ = session.client.send_request(
+            seq,
+            "setBreakpoints",
+            json!({
+                "source": { "path": path.display().to_string() },
+                "breakpoints": bps_json,
+            }),
+        );
+    }
+}
+
+fn parse_stack_frames(body: &Value) -> Vec<StackFrame> {
+    let mut out = Vec::new();
+    let Some(arr) = body.get("stackFrames").and_then(|v| v.as_array()) else {
+        return out;
+    };
+    for f in arr {
+        let id = f.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
+        let name = f
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let line = f.get("line").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        let column = f.get("column").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        let source = f
+            .get("source")
+            .and_then(|s| s.get("path"))
+            .and_then(|p| p.as_str())
+            .map(PathBuf::from);
+        out.push(StackFrame {
+            id,
+            name,
+            source,
+            line,
+            column,
+        });
+    }
+    out
 }
 
 #[cfg(test)]
@@ -103,7 +540,6 @@ mod tests {
         assert!(m.has_breakpoint(&p, 10));
         assert!(!m.toggle_breakpoint(&p, 10));
         assert!(!m.has_breakpoint(&p, 10));
-        // Map entry pruned when the last breakpoint is removed.
         assert!(m.breakpoints.is_empty());
     }
 
@@ -124,5 +560,15 @@ mod tests {
         let mut m = DapManager::new();
         assert!(!m.is_active());
         assert!(m.drain().is_empty());
+    }
+
+    #[test]
+    fn step_on_idle_manager_is_noop() {
+        // Without a session, step() should not panic — it just early-returns.
+        let m = DapManager::new();
+        m.step(StepKind::Continue);
+        m.step(StepKind::Next);
+        m.step(StepKind::StepIn);
+        m.step(StepKind::StepOut);
     }
 }

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -167,7 +167,10 @@ impl DapManager {
                 json!({
                     "clientID": "binvim",
                     "clientName": "binvim",
-                    "adapterID": adapter.key,
+                    // VSCode's well-known type id for .NET — netcoredbg
+                    // (and other adapters) gate behaviour on it. Our
+                    // internal `adapter.key` ("dotnet") wouldn't match.
+                    "adapterID": "coreclr",
                     "pathFormat": "path",
                     "linesStartAt1": true,
                     "columnsStartAt1": true,
@@ -237,13 +240,51 @@ impl DapManager {
     pub fn drain(&mut self) -> Vec<DapEvent> {
         let mut events = Vec::new();
         let mut msgs = Vec::new();
+        let mut stderr_lines: Vec<OutputLine> = Vec::new();
+        let mut exit_code: Option<i32> = None;
         if let Some(session) = self.session.as_ref() {
             while let Ok(msg) = session.client.incoming_rx.try_recv() {
                 msgs.push(msg);
             }
+            while let Ok(line) = session.client.stderr_rx.try_recv() {
+                stderr_lines.push(line);
+            }
+            // If the adapter exited without going through `terminated`/
+            // `exited`, the reader thread will block forever — surface
+            // the crash so the user sees something instead of a hang.
+            exit_code = session.client.try_exit_status();
+        }
+        for line in stderr_lines {
+            // Stream into the output buffer so the pane shows whatever the
+            // adapter printed before dying.
+            let trimmed = line.output.clone();
+            self.output_buffer.push(line.clone());
+            if self.output_buffer.len() > OUTPUT_LOG_CAP {
+                let excess = self.output_buffer.len() - OUTPUT_LOG_CAP;
+                self.output_buffer.drain(0..excess);
+            }
+            events.push(DapEvent::Output(line));
+            // Mirror the freshest stderr line into the pane status so the
+            // user spots the crash without having to scroll the output.
+            if let Some(s) = self.session.as_mut() {
+                s.status_line = trimmed;
+            }
         }
         for msg in msgs {
             self.process_incoming(msg, &mut events);
+        }
+        if let Some(code) = exit_code {
+            // Don't double-report if the protocol path already saw
+            // `terminated` and cleared the session.
+            if self.session.is_some() {
+                let msg = format!("adapter exited unexpectedly (code {})", code);
+                if let Some(s) = self.session.as_mut() {
+                    s.state = SessionState::Terminated;
+                    s.status_line = msg.clone();
+                }
+                events.push(DapEvent::AdapterError(msg));
+                events.push(DapEvent::Terminated);
+            }
         }
         events
     }

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -408,6 +408,27 @@ impl DapManager {
             "stackTrace" => {
                 let frames = parse_stack_frames(&body);
                 let top_id = frames.first().map(|f| f.id);
+                if frames.is_empty() {
+                    // Some adapters require `threads` first before
+                    // they'll fill out stackTrace; some return empty
+                    // when called with a stale thread id. Surface
+                    // either case so the user sees something in the
+                    // pane instead of an indefinite "(no frames)".
+                    let total = body.get("totalFrames").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let line = OutputLine {
+                        category: "console".into(),
+                        output: format!(
+                            "stackTrace returned 0 frames (totalFrames={}) — adapter may need a threads request first",
+                            total
+                        ),
+                    };
+                    self.output_buffer.push(line.clone());
+                    if self.output_buffer.len() > OUTPUT_LOG_CAP {
+                        let excess = self.output_buffer.len() - OUTPUT_LOG_CAP;
+                        self.output_buffer.drain(0..excess);
+                    }
+                    events.push(DapEvent::Output(line));
+                }
                 if let Some(s) = self.session.as_mut() {
                     s.frames = frames;
                 }
@@ -484,12 +505,20 @@ impl DapManager {
                     s.current_thread = Some(thread_id);
                     s.status_line = format!("stopped — {}", reason);
                 }
-                // Kick off a stackTrace request so the pane has frames to
-                // show as soon as the user reads the "stopped" status.
+                // Ask for the live thread list and the top frame's stack
+                // back-to-back. netcoredbg in particular needs the
+                // `threads` round-trip before it'll produce a populated
+                // stackTrace for the just-stopped thread; without it,
+                // the response comes back with `stackFrames: []` and the
+                // pane stays empty even though execution paused.
                 if let Some(session) = self.session.as_ref() {
-                    let seq = session.client.alloc_seq();
+                    let threads_seq = session.client.alloc_seq();
+                    let _ = session
+                        .client
+                        .send_request(threads_seq, "threads", json!({}));
+                    let stack_seq = session.client.alloc_seq();
                     let _ = session.client.send_request(
-                        seq,
+                        stack_seq,
                         "stackTrace",
                         json!({
                             "threadId": thread_id,

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use super::client::DapClient;
 use super::specs::DapAdapterSpec;
 use super::types::{
-    DapEvent, DapIncoming, OutputLine, SessionState, SourceBreakpoint, StackFrame,
+    DapEvent, DapIncoming, OutputLine, Scope, SessionState, SourceBreakpoint, StackFrame, Variable,
 };
 
 #[derive(Default)]
@@ -37,6 +37,12 @@ pub struct DapSession {
     pub state: SessionState,
     pub frames: Vec<StackFrame>,
     pub current_thread: Option<u64>,
+    /// Variable scopes reported for the top frame (typically just "Locals").
+    /// Refreshed on each `stopped` event; cleared on `continued`.
+    pub scopes: Vec<Scope>,
+    /// Resolved locals for the first non-expensive scope. The pane shows
+    /// these directly. Expanding nested values is Phase 3 territory.
+    pub locals: Vec<Variable>,
     /// Spawned adapter process + reader channel. Dropping the session
     /// drops the child, which closes the reader thread on its own.
     pub client: DapClient,
@@ -178,6 +184,8 @@ impl DapManager {
             state: SessionState::Initializing,
             frames: Vec::new(),
             current_thread: None,
+            scopes: Vec::new(),
+            locals: Vec::new(),
             client,
             launch_args,
             status_line: "initialising adapter…".into(),
@@ -309,8 +317,45 @@ impl DapManager {
             }
             "stackTrace" => {
                 let frames = parse_stack_frames(&body);
+                let top_id = frames.first().map(|f| f.id);
                 if let Some(s) = self.session.as_mut() {
                     s.frames = frames;
+                }
+                // Auto-chain into scopes for the top frame so the pane can
+                // show locals without an extra command from the user.
+                if let (Some(id), Some(session)) = (top_id, self.session.as_ref()) {
+                    let seq = session.client.alloc_seq();
+                    let _ = session.client.send_request(
+                        seq,
+                        "scopes",
+                        json!({ "frameId": id }),
+                    );
+                }
+            }
+            "scopes" => {
+                let scopes = parse_scopes(&body);
+                // Pick the first non-expensive scope (typically "Locals").
+                let target = scopes
+                    .iter()
+                    .find(|s| !s.expensive)
+                    .map(|s| s.variables_reference);
+                if let Some(s) = self.session.as_mut() {
+                    s.scopes = scopes;
+                    s.locals.clear();
+                }
+                if let (Some(vref), Some(session)) = (target, self.session.as_ref()) {
+                    let seq = session.client.alloc_seq();
+                    let _ = session.client.send_request(
+                        seq,
+                        "variables",
+                        json!({ "variablesReference": vref }),
+                    );
+                }
+            }
+            "variables" => {
+                let vars = parse_variables(&body);
+                if let Some(s) = self.session.as_mut() {
+                    s.locals = vars;
                 }
             }
             _ => {}
@@ -378,6 +423,8 @@ impl DapManager {
                     .unwrap_or(false);
                 if let Some(s) = self.session.as_mut() {
                     s.frames.clear();
+                    s.scopes.clear();
+                    s.locals.clear();
                     s.current_thread = None;
                     if !matches!(s.state, SessionState::Terminated) {
                         s.state = SessionState::Running;
@@ -495,6 +542,62 @@ impl DapManager {
             }),
         );
     }
+}
+
+fn parse_scopes(body: &Value) -> Vec<Scope> {
+    let mut out = Vec::new();
+    let Some(arr) = body.get("scopes").and_then(|v| v.as_array()) else {
+        return out;
+    };
+    for s in arr {
+        let name = s
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let variables_reference = s
+            .get("variablesReference")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let expensive = s.get("expensive").and_then(|v| v.as_bool()).unwrap_or(false);
+        out.push(Scope {
+            name,
+            variables_reference,
+            expensive,
+        });
+    }
+    out
+}
+
+fn parse_variables(body: &Value) -> Vec<Variable> {
+    let mut out = Vec::new();
+    let Some(arr) = body.get("variables").and_then(|v| v.as_array()) else {
+        return out;
+    };
+    for v in arr {
+        let name = v
+            .get("name")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string();
+        let value = v
+            .get("value")
+            .and_then(|x| x.as_str())
+            .unwrap_or("")
+            .to_string();
+        let type_name = v.get("type").and_then(|x| x.as_str()).map(|s| s.to_string());
+        let variables_reference = v
+            .get("variablesReference")
+            .and_then(|x| x.as_u64())
+            .unwrap_or(0);
+        out.push(Variable {
+            name,
+            value,
+            type_name,
+            variables_reference,
+        });
+    }
+    out
 }
 
 fn parse_stack_frames(body: &Value) -> Vec<StackFrame> {

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -600,6 +600,50 @@ impl DapManager {
                     .to_string();
                 events.push(DapEvent::Thread { reason, thread_id });
             }
+            // netcoredbg fires this when a previously-pending
+            // breakpoint binds after a JIT, or when it rebinds an
+            // existing one to a different line (common for lambdas:
+            // line N → line N-3 of the enclosing call). Surface the
+            // change so the user sees that the breakpoint actually
+            // landed somewhere — and where.
+            "breakpoint" => {
+                let reason = body
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if let Some(bp) = body.get("breakpoint") {
+                    let verified = bp
+                        .get("verified")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let line = bp.get("line").and_then(|v| v.as_u64()).unwrap_or(0);
+                    let msg = bp
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let summary = match (reason.as_str(), verified, msg) {
+                        ("changed", true, _) => format!("breakpoint bound at line {line}"),
+                        ("changed", false, Some(m)) => format!("breakpoint line {line}: {m}"),
+                        ("changed", false, None) => format!("breakpoint line {line}: still pending"),
+                        ("removed", _, _) => format!("breakpoint at line {line} removed by adapter"),
+                        (r, _, _) => format!("breakpoint event ({r}) at line {line}"),
+                    };
+                    if let Some(s) = self.session.as_mut() {
+                        s.status_line = summary.clone();
+                    }
+                    let line = OutputLine {
+                        category: "console".into(),
+                        output: summary,
+                    };
+                    self.output_buffer.push(line.clone());
+                    if self.output_buffer.len() > OUTPUT_LOG_CAP {
+                        let excess = self.output_buffer.len() - OUTPUT_LOG_CAP;
+                        self.output_buffer.drain(0..excess);
+                    }
+                    events.push(DapEvent::Output(line));
+                }
+            }
             _ => {}
         }
     }

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -1,0 +1,128 @@
+//! `DapManager` owns at most one debug session plus the user's breakpoint
+//! table. Phase 1: just the data shell + breakpoint mutators — no session
+//! lifecycle yet. The Phase 2 work adds spawn / handshake / step / variable
+//! fetch driven by an internal `DapClient` and reader-thread channel.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use super::types::{DapEvent, OutputLine, SessionState, SourceBreakpoint, StackFrame};
+
+#[derive(Default)]
+#[allow(dead_code)]
+pub struct DapManager {
+    /// Breakpoints the user has toggled in the editor, keyed by absolute
+    /// path. Persisted across sessions in memory so re-launching reuses
+    /// them. The map outlives any session.
+    pub breakpoints: HashMap<PathBuf, Vec<SourceBreakpoint>>,
+    /// Active session, if any. `None` between launches.
+    pub session: Option<DapSession>,
+    /// Backlog of debug-console output captured before the panel was opened
+    /// or while no UI was rendering. Drained by the renderer.
+    pub output_buffer: Vec<OutputLine>,
+}
+
+#[allow(dead_code)]
+pub struct DapSession {
+    /// Adapter spec key — `"dotnet"`, `"go"`, … — for status display.
+    pub adapter_key: String,
+    /// Workspace root the session was launched against.
+    pub workspace_root: PathBuf,
+    /// Current high-level state.
+    pub state: SessionState,
+    /// Call stack of the currently-stopped thread, if any.
+    pub frames: Vec<StackFrame>,
+    /// Stopped thread id, if a `stopped` event has been received.
+    pub current_thread: Option<u64>,
+}
+
+impl DapManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// True when there is a session attempting to drive (or driving) a
+    /// debuggee. Used by the renderer to decide whether to show the
+    /// placeholder text or the real panes.
+    #[allow(dead_code)]
+    pub fn is_active(&self) -> bool {
+        self.session
+            .as_ref()
+            .map(|s| !matches!(s.state, SessionState::Terminated))
+            .unwrap_or(false)
+    }
+
+    /// Toggle a line breakpoint. Returns the new state (`true` if the
+    /// breakpoint now exists, `false` if it was removed).
+    #[allow(dead_code)]
+    pub fn toggle_breakpoint(&mut self, path: &Path, line: usize) -> bool {
+        let entry = self.breakpoints.entry(path.to_path_buf()).or_default();
+        if let Some(idx) = entry.iter().position(|b| b.line == line) {
+            entry.remove(idx);
+            if entry.is_empty() {
+                self.breakpoints.remove(path);
+            }
+            false
+        } else {
+            entry.push(SourceBreakpoint {
+                line,
+                condition: None,
+            });
+            true
+        }
+    }
+
+    /// True when `path` has a user-set breakpoint at `line`. Renderer-side
+    /// gutter marker uses this.
+    #[allow(dead_code)]
+    pub fn has_breakpoint(&self, path: &Path, line: usize) -> bool {
+        self.breakpoints
+            .get(path)
+            .map(|v| v.iter().any(|b| b.line == line))
+            .unwrap_or(false)
+    }
+
+    /// Phase-1 placeholder. The real implementation drains the reader-thread
+    /// channel and translates raw `DapIncoming`s into `DapEvent`s.
+    #[allow(dead_code)]
+    pub fn drain(&mut self) -> Vec<DapEvent> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn toggle_breakpoint_adds_and_removes() {
+        let mut m = DapManager::new();
+        let p = PathBuf::from("/tmp/x.cs");
+        assert!(!m.has_breakpoint(&p, 10));
+        assert!(m.toggle_breakpoint(&p, 10));
+        assert!(m.has_breakpoint(&p, 10));
+        assert!(!m.toggle_breakpoint(&p, 10));
+        assert!(!m.has_breakpoint(&p, 10));
+        // Map entry pruned when the last breakpoint is removed.
+        assert!(m.breakpoints.is_empty());
+    }
+
+    #[test]
+    fn breakpoint_table_is_per_path() {
+        let mut m = DapManager::new();
+        let a = PathBuf::from("/tmp/a.cs");
+        let b = PathBuf::from("/tmp/b.cs");
+        m.toggle_breakpoint(&a, 5);
+        m.toggle_breakpoint(&b, 5);
+        assert!(m.has_breakpoint(&a, 5));
+        assert!(m.has_breakpoint(&b, 5));
+        assert_eq!(m.breakpoints.len(), 2);
+    }
+
+    #[test]
+    fn idle_manager_is_inactive_and_drains_empty() {
+        let mut m = DapManager::new();
+        assert!(!m.is_active());
+        assert!(m.drain().is_empty());
+    }
+}

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -356,6 +356,55 @@ impl DapManager {
                     s.status_line = "running".into();
                 }
             }
+            // netcoredbg reports per-breakpoint validation in the
+            // response — surface unverified ones to the status line and
+            // output pane so the user spots a missing-PDB / wrong-line
+            // / "bind by pattern" misfire without a silent never-hits.
+            "setBreakpoints" => {
+                let mut unverified: Vec<(u64, String)> = Vec::new();
+                if let Some(arr) = body.get("breakpoints").and_then(|v| v.as_array()) {
+                    for bp in arr {
+                        let verified = bp
+                            .get("verified")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false);
+                        if !verified {
+                            let line = bp.get("line").and_then(|v| v.as_u64()).unwrap_or(0);
+                            let reason = bp
+                                .get("message")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("not bound (often: line is not an executable statement — try inside the handler body)")
+                                .to_string();
+                            unverified.push((line, reason));
+                        }
+                    }
+                }
+                if !unverified.is_empty() {
+                    let lines = unverified
+                        .iter()
+                        .map(|(l, r)| format!("line {l}: {r}"))
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    let summary = format!(
+                        "{} breakpoint(s) unverified — {}",
+                        unverified.len(),
+                        lines
+                    );
+                    if let Some(s) = self.session.as_mut() {
+                        s.status_line = summary.clone();
+                    }
+                    let line = OutputLine {
+                        category: "console".into(),
+                        output: summary,
+                    };
+                    self.output_buffer.push(line.clone());
+                    if self.output_buffer.len() > OUTPUT_LOG_CAP {
+                        let excess = self.output_buffer.len() - OUTPUT_LOG_CAP;
+                        self.output_buffer.drain(0..excess);
+                    }
+                    events.push(DapEvent::Output(line));
+                }
+            }
             "stackTrace" => {
                 let frames = parse_stack_frames(&body);
                 let top_id = frames.first().map(|f| f.id);

--- a/src/dap/manager.rs
+++ b/src/dap/manager.rs
@@ -5,7 +5,7 @@
 //! pull the resulting `DapEvent`s off and react.
 
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use super::client::DapClient;
@@ -40,9 +40,24 @@ pub struct DapSession {
     /// Variable scopes reported for the top frame (typically just "Locals").
     /// Refreshed on each `stopped` event; cleared on `continued`.
     pub scopes: Vec<Scope>,
-    /// Resolved locals for the first non-expensive scope. The pane shows
-    /// these directly. Expanding nested values is Phase 3 territory.
-    pub locals: Vec<Variable>,
+    /// `variables_reference` of the scope whose contents are displayed in
+    /// the pane as "locals". Picked as the first non-expensive scope on
+    /// each stop; expansion further into structured values lives in
+    /// `children` and `expanded`.
+    pub scope_for_display: Option<u64>,
+    /// Cached children per `variables_reference`. The pane's root locals
+    /// are `children[scope_for_display]`; expanding a variable populates
+    /// `children[var.variables_reference]` lazily.
+    pub children: HashMap<u64, Vec<Variable>>,
+    /// `variables_reference`s the user has toggled open. Persisted across
+    /// pane re-renders; cleared on each stop so stale handles don't leak
+    /// between stops (DAP doesn't promise vref stability).
+    pub expanded: HashSet<u64>,
+    /// In-flight `variables` requests — `request_seq → parent_vref`. Lets
+    /// the response handler store children under the right parent when
+    /// several fetches are outstanding (e.g. user expands a deeply-nested
+    /// branch quickly).
+    pub pending_variable_fetches: HashMap<u64, u64>,
     /// Spawned adapter process + reader channel. Dropping the session
     /// drops the child, which closes the reader thread on its own.
     pub client: DapClient,
@@ -188,7 +203,10 @@ impl DapManager {
             frames: Vec::new(),
             current_thread: None,
             scopes: Vec::new(),
-            locals: Vec::new(),
+            scope_for_display: None,
+            children: HashMap::new(),
+            expanded: HashSet::new(),
+            pending_variable_fetches: HashMap::new(),
             client,
             launch_args,
             status_line: "initialising adapter…".into(),
@@ -217,6 +235,57 @@ impl DapManager {
     /// One step / continue command targeted at the currently-stopped
     /// thread. Silently does nothing if the session isn't in a stopped
     /// state — the calling key/command handler decides whether to warn.
+    /// Flip whether `vref` is expanded in the pane's locals tree. Returns
+    /// the new state. When expanding for the first time, kicks off a DAP
+    /// `variables` request so the children populate asynchronously.
+    pub fn toggle_expanded(&mut self, vref: u64) -> bool {
+        let now_expanded = match self.session.as_mut() {
+            Some(s) if s.expanded.contains(&vref) => {
+                s.expanded.remove(&vref);
+                false
+            }
+            Some(s) => {
+                s.expanded.insert(vref);
+                true
+            }
+            None => return false,
+        };
+        if now_expanded {
+            // Only fetch if we haven't cached this set of children yet.
+            let need_fetch = self
+                .session
+                .as_ref()
+                .map(|s| !s.children.contains_key(&vref))
+                .unwrap_or(false);
+            if need_fetch {
+                self.request_variables(vref);
+            }
+        }
+        now_expanded
+    }
+
+    /// Send a `variables` request and record the `seq → parent_vref`
+    /// mapping so the response handler stores children under the right
+    /// parent. Idempotency of in-flight requests is the caller's problem;
+    /// double-firing just produces two responses that both write the same
+    /// `children[vref]` entry.
+    fn request_variables(&mut self, vref: u64) {
+        let Some(session) = self.session.as_ref() else {
+            return;
+        };
+        let seq = session.client.alloc_seq();
+        if session
+            .client
+            .send_request(seq, "variables", json!({ "variablesReference": vref }))
+            .is_err()
+        {
+            return;
+        }
+        if let Some(s) = self.session.as_mut() {
+            s.pending_variable_fetches.insert(seq, vref);
+        }
+    }
+
     pub fn step(&self, kind: StepKind) {
         let Some(session) = self.session.as_ref() else {
             return;
@@ -292,12 +361,12 @@ impl DapManager {
     fn process_incoming(&mut self, msg: DapIncoming, events: &mut Vec<DapEvent>) {
         match msg {
             DapIncoming::Response {
+                request_seq,
                 command,
                 success,
                 body,
                 message,
-                ..
-            } => self.handle_response(command, success, body, message, events),
+            } => self.handle_response(request_seq, command, success, body, message, events),
             DapIncoming::Event { event, body } => self.handle_event(event, body, events),
             DapIncoming::Request {
                 seq, command, ..
@@ -315,6 +384,7 @@ impl DapManager {
 
     fn handle_response(
         &mut self,
+        request_seq: u64,
         command: String,
         success: bool,
         body: Value,
@@ -445,28 +515,32 @@ impl DapManager {
             }
             "scopes" => {
                 let scopes = parse_scopes(&body);
-                // Pick the first non-expensive scope (typically "Locals").
+                // Pick the first non-expensive scope (typically "Locals"
+                // for stack-based languages, "Arguments + Locals" for C#).
                 let target = scopes
                     .iter()
                     .find(|s| !s.expensive)
                     .map(|s| s.variables_reference);
                 if let Some(s) = self.session.as_mut() {
                     s.scopes = scopes;
-                    s.locals.clear();
+                    s.scope_for_display = target;
+                    s.children.clear();
+                    s.expanded.clear();
+                    s.pending_variable_fetches.clear();
                 }
-                if let (Some(vref), Some(session)) = (target, self.session.as_ref()) {
-                    let seq = session.client.alloc_seq();
-                    let _ = session.client.send_request(
-                        seq,
-                        "variables",
-                        json!({ "variablesReference": vref }),
-                    );
+                if let Some(vref) = target {
+                    self.request_variables(vref);
                 }
             }
             "variables" => {
                 let vars = parse_variables(&body);
                 if let Some(s) = self.session.as_mut() {
-                    s.locals = vars;
+                    if let Some(parent_vref) = s.pending_variable_fetches.remove(&request_seq) {
+                        s.children.insert(parent_vref, vars);
+                    } else {
+                        // No mapping — most likely a stale response from
+                        // before the last stop. Discard quietly.
+                    }
                 }
             }
             _ => {}
@@ -504,6 +578,14 @@ impl DapManager {
                     };
                     s.current_thread = Some(thread_id);
                     s.status_line = format!("stopped — {}", reason);
+                    // `variables_reference` numbers aren't guaranteed
+                    // stable across stops — drop the cached tree state
+                    // before we re-fetch scopes for the new top frame.
+                    s.scopes.clear();
+                    s.scope_for_display = None;
+                    s.children.clear();
+                    s.expanded.clear();
+                    s.pending_variable_fetches.clear();
                 }
                 // Ask for the live thread list and the top frame's stack
                 // back-to-back. netcoredbg in particular needs the
@@ -543,7 +625,10 @@ impl DapManager {
                 if let Some(s) = self.session.as_mut() {
                     s.frames.clear();
                     s.scopes.clear();
-                    s.locals.clear();
+                    s.scope_for_display = None;
+                    s.children.clear();
+                    s.expanded.clear();
+                    s.pending_variable_fetches.clear();
                     s.current_thread = None;
                     if !matches!(s.state, SessionState::Terminated) {
                         s.state = SessionState::Running;
@@ -791,6 +876,55 @@ fn parse_stack_frames(body: &Value) -> Vec<StackFrame> {
         });
     }
     out
+}
+
+/// One row in the flattened locals tree. The pane renderer prints these
+/// with indentation; the pane-focus key handler indexes into the slice
+/// by `App.dap_pane_cursor` to figure out which variable Enter/Tab
+/// should toggle.
+pub struct FlatLocalRow<'a> {
+    pub depth: usize,
+    pub var: &'a Variable,
+    pub expandable: bool,
+    pub expanded: bool,
+}
+
+/// Flatten the session's locals tree, honouring the current `expanded`
+/// set. Returns an empty `Vec` whenever locals aren't available yet
+/// (running state, no scope picked, response in flight, …).
+pub fn flat_locals_view(session: &DapSession) -> Vec<FlatLocalRow<'_>> {
+    let mut out = Vec::new();
+    let Some(root_vref) = session.scope_for_display else {
+        return out;
+    };
+    let Some(roots) = session.children.get(&root_vref) else {
+        return out;
+    };
+    walk_locals(session, roots, 0, &mut out);
+    out
+}
+
+fn walk_locals<'a>(
+    session: &'a DapSession,
+    vars: &'a [Variable],
+    depth: usize,
+    out: &mut Vec<FlatLocalRow<'a>>,
+) {
+    for v in vars {
+        let expandable = v.variables_reference > 0;
+        let expanded = expandable && session.expanded.contains(&v.variables_reference);
+        out.push(FlatLocalRow {
+            depth,
+            var: v,
+            expandable,
+            expanded,
+        });
+        if expanded {
+            if let Some(children) = session.children.get(&v.variables_reference) {
+                walk_locals(session, children, depth + 1, out);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/dap/specs.rs
+++ b/src/dap/specs.rs
@@ -1,0 +1,212 @@
+//! Debug-adapter registry. `adapter_for_workspace` picks the right adapter
+//! for a workspace by walking up from a starting path looking for the
+//! adapter's root markers. Adding an adapter means appending one
+//! `DapAdapterSpec` to `BUILTIN_ADAPTERS`.
+//!
+//! Helpers `find_workspace_root` and `resolve_command` are duplicated from
+//! `lsp::specs` rather than re-exported — the DAP layer is conceptually
+//! independent of the LSP layer and shouldn't cross-import.
+
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+
+/// One debug adapter the editor knows how to launch.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct DapAdapterSpec {
+    /// Stable key — `"dotnet"`, `"go"`, `"python"`, …
+    pub key: &'static str,
+    /// Process candidates in priority order. First one that resolves on
+    /// `$PATH` (or as an absolute path) wins.
+    pub cmd_candidates: &'static [&'static str],
+    /// Args appended to the adapter command. Typically the interpreter
+    /// flag (`--interpreter=vscode` for netcoredbg).
+    pub args: &'static [&'static str],
+    /// Filenames / globs whose presence marks a workspace this adapter
+    /// claims. `*.ext` is honoured as "any file with that extension in
+    /// the directory."
+    pub root_markers: &'static [&'static str],
+    /// Optional pre-launch step — run before sending `launch` to the
+    /// adapter. For .NET this is `dotnet build`.
+    pub prelaunch: Option<PrelaunchCommand>,
+    /// Builds the `launch` request `arguments` JSON for this adapter
+    /// given the resolved workspace root. Phase 2 fills this in for real;
+    /// Phase 1 ships a placeholder so the type carries the shape.
+    pub build_launch_args: fn(root: &Path) -> Value,
+}
+
+/// A shell command to run before the adapter session starts. `args` are
+/// passed through; the runner uses the resolved workspace root as cwd.
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub struct PrelaunchCommand {
+    pub program: &'static str,
+    pub args: &'static [&'static str],
+    /// Human-readable label for the status line ("Building…", "Compiling…").
+    pub label: &'static str,
+}
+
+/// All adapters binvim ships with. Order doesn't matter — `adapter_for_workspace`
+/// returns the first one whose root markers match.
+const BUILTIN_ADAPTERS: &[DapAdapterSpec] = &[DOTNET];
+
+const DOTNET: DapAdapterSpec = DapAdapterSpec {
+    key: "dotnet",
+    cmd_candidates: &["netcoredbg"],
+    args: &["--interpreter=vscode"],
+    root_markers: &["*.csproj", "*.sln", "*.fsproj"],
+    prelaunch: Some(PrelaunchCommand {
+        program: "dotnet",
+        args: &["build", "-c", "Debug"],
+        label: "Building .NET project",
+    }),
+    build_launch_args: dotnet_launch_args,
+};
+
+/// Phase-1 placeholder. Real launch-args resolution (find the built dll
+/// in `bin/Debug/netN.0/`, fill in `program` / `console` / `cwd`) lands
+/// with the session-lifecycle work in Phase 2.
+#[allow(dead_code)]
+fn dotnet_launch_args(root: &Path) -> Value {
+    json!({
+        "name": ".NET Core Launch",
+        "type": "coreclr",
+        "request": "launch",
+        "cwd": root.display().to_string(),
+        "console": "internalConsole",
+        "stopAtEntry": false,
+    })
+}
+
+/// Pick the adapter that claims `start_dir`, walking up parent directories
+/// looking for any spec's root markers. Returns the spec and the resolved
+/// workspace root (the directory the marker was found in).
+#[allow(dead_code)]
+pub fn adapter_for_workspace(start: &Path) -> Option<(DapAdapterSpec, PathBuf)> {
+    for spec in BUILTIN_ADAPTERS {
+        let markers: Vec<String> = spec.root_markers.iter().map(|s| s.to_string()).collect();
+        let root = find_workspace_root(start, &markers);
+        if has_any_marker(&root, &markers) {
+            return Some((spec.clone(), root));
+        }
+    }
+    None
+}
+
+/// Walk up from `start` until any of `markers` is found in a directory.
+/// `*.ext` markers match any file in the directory with that extension.
+/// Returns the matching directory, or the canonical form of `start` if
+/// nothing was found (so callers can still emit a useful path).
+pub fn find_workspace_root(start: &Path, markers: &[String]) -> PathBuf {
+    let canon = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
+    let mut dir: &Path = canon.as_path();
+    loop {
+        if has_any_marker(dir, markers) {
+            return dir.to_path_buf();
+        }
+        match dir.parent() {
+            Some(p) if p != dir => dir = p,
+            _ => break,
+        }
+    }
+    canon
+}
+
+fn has_any_marker(dir: &Path, markers: &[String]) -> bool {
+    for marker in markers {
+        if let Some(ext) = marker.strip_prefix("*.") {
+            if dir_contains_extension(dir, ext) {
+                return true;
+            }
+        } else if dir.join(marker).exists() {
+            return true;
+        }
+    }
+    false
+}
+
+fn dir_contains_extension(dir: &Path, ext: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        if let Some(file_ext) = entry.path().extension().and_then(|e| e.to_str()) {
+            if file_ext.eq_ignore_ascii_case(ext) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Resolve the first command candidate to an absolute path. Bare names go
+/// through `$PATH`; absolute / relative paths must exist on disk. `~/` is
+/// expanded against `$HOME`. Returns `None` if nothing resolves.
+#[allow(dead_code)]
+pub fn resolve_command(candidates: &[&str]) -> Option<String> {
+    for c in candidates {
+        let path = if let Some(rest) = c.strip_prefix("~/") {
+            let home = std::env::var("HOME").ok()?;
+            format!("{}/{}", home, rest)
+        } else {
+            (*c).to_string()
+        };
+        if path.contains('/') {
+            if Path::new(&path).is_file() {
+                return Some(path);
+            }
+            continue;
+        }
+        if let Some(found) = which_in_path(&path) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn which_in_path(name: &str) -> Option<String> {
+    let path = std::env::var("PATH").ok()?;
+    for dir in path.split(':') {
+        let full = Path::new(dir).join(name);
+        if full.is_file() {
+            return Some(full.to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn adapter_for_workspace_finds_dotnet_via_csproj() {
+        let tmp = std::env::temp_dir().join("binvim_dap_test_csproj");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+        fs::write(tmp.join("hello.csproj"), "<Project/>").unwrap();
+        let found = adapter_for_workspace(&tmp).expect("should find dotnet adapter");
+        assert_eq!(found.0.key, "dotnet");
+        assert_eq!(found.1.canonicalize().unwrap(), tmp.canonicalize().unwrap());
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn adapter_for_workspace_finds_nothing_for_empty_dir() {
+        let tmp = std::env::temp_dir().join("binvim_dap_test_empty");
+        let _ = fs::remove_dir_all(&tmp);
+        fs::create_dir_all(&tmp).unwrap();
+        assert!(adapter_for_workspace(&tmp).is_none());
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_command_picks_first_existing() {
+        // /bin/sh exists on macOS and Linux; this is a stable target.
+        let found = resolve_command(&["definitely_not_a_real_binary_xyz", "sh"]);
+        assert!(found.is_some());
+        let s = found.unwrap();
+        assert!(s.ends_with("/sh"), "expected absolute path ending in /sh, got {s}");
+    }
+}

--- a/src/dap/specs.rs
+++ b/src/dap/specs.rs
@@ -121,7 +121,17 @@ fn dotnet_launch_payload(program: &Path, cwd: &Path) -> Value {
         "cwd": cwd.display().to_string(),
         "console": "internalConsole",
         "stopAtEntry": false,
-        "justMyCode": true,
+        // Off so breakpoints inside minimal-API endpoint lambdas — which
+        // dispatch through framework code — actually bind on JIT. With
+        // JMC on, netcoredbg silently rebinds the breakpoint to the
+        // nearest user-code sequence point (the MapGet registration
+        // line), so it fires once during startup and never again on
+        // request.
+        "justMyCode": false,
+        // Tell the adapter we don't care if the source file's hash
+        // matches the PDB — useful when the user has edited the file
+        // since the last build but hasn't re-built yet.
+        "requireExactSource": false,
     })
 }
 

--- a/src/dap/specs.rs
+++ b/src/dap/specs.rs
@@ -30,9 +30,10 @@ pub struct DapAdapterSpec {
     /// adapter. For .NET this is `dotnet build`.
     pub prelaunch: Option<PrelaunchCommand>,
     /// Builds the `launch` request `arguments` JSON for this adapter
-    /// given the resolved workspace root. Phase 2 fills this in for real;
-    /// Phase 1 ships a placeholder so the type carries the shape.
-    pub build_launch_args: fn(root: &Path) -> Value,
+    /// given the resolved workspace root. Returning `Err` aborts the
+    /// session start before the adapter is spawned (avoids leaking a
+    /// process if the build output can't be located).
+    pub build_launch_args: fn(root: &Path) -> Result<Value, String>,
 }
 
 /// A shell command to run before the adapter session starts. `args` are
@@ -63,18 +64,64 @@ const DOTNET: DapAdapterSpec = DapAdapterSpec {
     build_launch_args: dotnet_launch_args,
 };
 
-/// Phase-1 placeholder. Real launch-args resolution (find the built dll
-/// in `bin/Debug/netN.0/`, fill in `program` / `console` / `cwd`) lands
-/// with the session-lifecycle work in Phase 2.
-#[allow(dead_code)]
-fn dotnet_launch_args(root: &Path) -> Value {
+/// Locate the built `*.dll` under `bin/Debug/netN.0/` and build the
+/// `launch` arguments netcoredbg expects. Prefers `<root-name>.dll` and
+/// the most recently modified `net*` subdirectory, so the .NET 10 build
+/// wins when older targets are also present.
+fn dotnet_launch_args(root: &Path) -> Result<Value, String> {
+    let bin = root.join("bin").join("Debug");
+    if !bin.is_dir() {
+        return Err(format!(
+            "no Debug build output at {} — has the project been built?",
+            bin.display()
+        ));
+    }
+    let project_name = root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("")
+        .to_string();
+    let mut frameworks: Vec<std::path::PathBuf> = std::fs::read_dir(&bin)
+        .map_err(|e| format!("cannot read {}: {}", bin.display(), e))?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    frameworks.sort_by_key(|p| {
+        std::fs::metadata(p)
+            .and_then(|m| m.modified())
+            .ok()
+    });
+    frameworks.reverse();
+
+    for fw in &frameworks {
+        let preferred = fw.join(format!("{}.dll", project_name));
+        if preferred.is_file() {
+            return Ok(dotnet_launch_payload(&preferred, root));
+        }
+    }
+    for fw in &frameworks {
+        let Ok(entries) = std::fs::read_dir(fw) else { continue };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.extension().and_then(|s| s.to_str()) == Some("dll") {
+                return Ok(dotnet_launch_payload(&p, root));
+            }
+        }
+    }
+    Err(format!("no *.dll found under {}", bin.display()))
+}
+
+fn dotnet_launch_payload(program: &Path, cwd: &Path) -> Value {
     json!({
         "name": ".NET Core Launch",
         "type": "coreclr",
         "request": "launch",
-        "cwd": root.display().to_string(),
+        "program": program.display().to_string(),
+        "cwd": cwd.display().to_string(),
         "console": "internalConsole",
         "stopAtEntry": false,
+        "justMyCode": true,
     })
 }
 

--- a/src/dap/types.rs
+++ b/src/dap/types.rs
@@ -1,0 +1,168 @@
+//! Wire-side and editor-side data types for the DAP layer.
+//!
+//! `DapIncoming` is what the reader thread emits — the raw shape of one
+//! parsed adapter message. `DapEvent` is what the manager turns those into
+//! after the protocol semantics are resolved (response ↔ original request
+//! matched, lifecycle events promoted, etc.). The main loop only sees
+//! `DapEvent`s.
+
+use serde_json::Value;
+use std::path::PathBuf;
+
+/// One message just lifted off the adapter's stdout. Differs from LSP's
+/// shape — DAP's request/response/event split is explicit in the `type`
+/// field, and responses carry a `success` bool plus the original command
+/// name.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub enum DapIncoming {
+    /// Server-emitted event (e.g. `stopped`, `output`, `terminated`).
+    Event { event: String, body: Value },
+    /// Reply to a request we sent.
+    Response {
+        request_seq: u64,
+        command: String,
+        success: bool,
+        body: Value,
+        /// Adapter-supplied error message — only meaningful when `!success`.
+        message: Option<String>,
+    },
+    /// Server-to-client request — DAP allows these for `runInTerminal` and
+    /// similar. The main thread handles + replies, mirroring the LSP
+    /// `workspace/applyEdit` pattern.
+    Request {
+        seq: u64,
+        command: String,
+        arguments: Value,
+    },
+}
+
+/// Editor-facing debug events. The manager translates raw `DapIncoming`s
+/// into these after binding responses to their originating requests.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum DapEvent {
+    /// Adapter answered `initialize` — capabilities are now known.
+    Initialized,
+    /// Program paused. `reason` is the DAP reason string ("breakpoint",
+    /// "step", "exception", "pause", "entry", …).
+    Stopped {
+        thread_id: u64,
+        reason: String,
+        description: Option<String>,
+        hit_breakpoint_ids: Vec<u64>,
+    },
+    /// Program resumed.
+    Continued {
+        thread_id: Option<u64>,
+        all_threads: bool,
+    },
+    /// Console output emitted by the debuggee (or the adapter).
+    Output(OutputLine),
+    /// Thread lifecycle. `reason` is "started" or "exited".
+    Thread { reason: String, thread_id: u64 },
+    /// One breakpoint's verified state changed (set / cleared / moved
+    /// after symbol load).
+    Breakpoint { reason: String, breakpoint: Breakpoint },
+    /// Debuggee exited normally.
+    Exited { exit_code: i64 },
+    /// Session torn down (adapter exit, user-initiated, or error).
+    Terminated,
+    /// Adapter spoke an error we can't recover from — surface to the user.
+    AdapterError(String),
+}
+
+/// One line in the debug console pane. Categories come straight from DAP:
+/// "console", "stdout", "stderr", "telemetry", "important". The pane
+/// renders different categories with different colours.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct OutputLine {
+    pub category: String,
+    pub output: String,
+}
+
+/// A source-line breakpoint as the user set it in the editor. Independent
+/// of any active session — the manager keeps a per-path table and resends
+/// `setBreakpoints` to the adapter whenever a session starts or this list
+/// changes.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct SourceBreakpoint {
+    pub line: usize,
+    /// User-supplied conditional expression. Phase-2 territory — none of
+    /// the keybindings expose this yet.
+    pub condition: Option<String>,
+}
+
+/// Breakpoint state as reported back by the adapter — verified flag,
+/// resolved location after symbol load, optional adapter id.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Breakpoint {
+    /// Adapter-assigned id, present once the adapter has acknowledged it.
+    pub id: Option<u64>,
+    pub verified: bool,
+    /// Resolved path — may differ from where the user set it if the
+    /// adapter mapped through a symbol search.
+    pub source: Option<PathBuf>,
+    /// Resolved line, 1-based as DAP defines it.
+    pub line: Option<usize>,
+    /// Adapter explanation for unverified breakpoints ("no executable code
+    /// at this line", "module not loaded yet", …).
+    pub message: Option<String>,
+}
+
+/// One frame of the stopped thread's call stack.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct StackFrame {
+    pub id: u64,
+    pub name: String,
+    pub source: Option<PathBuf>,
+    /// 1-based per DAP convention.
+    pub line: usize,
+    pub column: usize,
+}
+
+/// A variable scope ("Locals", "Globals", "Arguments", …) within a frame.
+/// The `variables_reference` is the DAP handle for the lazy fetch.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Scope {
+    pub name: String,
+    pub variables_reference: u64,
+    pub expensive: bool,
+}
+
+/// A single named value inside a scope or another structured variable.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Variable {
+    pub name: String,
+    pub value: String,
+    pub type_name: Option<String>,
+    /// Non-zero when the value has children that can be expanded.
+    pub variables_reference: u64,
+}
+
+/// The high-level state machine for an active session. Transitions are
+/// driven by responses + events from the adapter; the renderer reads this
+/// to decide which placeholder to paint.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub enum SessionState {
+    /// `initialize` sent, awaiting capabilities response.
+    Initializing,
+    /// Capabilities back; `launch` sent (or about to be), awaiting the
+    /// `initialized` event before pushing breakpoints.
+    Configuring,
+    /// `configurationDone` sent and acknowledged — debuggee is or will
+    /// shortly be running.
+    Running,
+    /// Adapter reported a `stopped` event. The frame + scope state on the
+    /// manager applies to `thread_id`.
+    Stopped { thread_id: u64, reason: String },
+    /// Adapter or debuggee terminated. Session can be cleared.
+    Terminated,
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -21,12 +21,18 @@ pub fn format_buffer(path: &Path, source: &str) -> Result<String, String> {
         "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" | "json" | "jsonc" => {
             run_biome(path, source)
         }
-        // csharpier handles .cs but explicitly rejects .cshtml/.razor (it
-        // warns "unsupported file type" and exits 0). Send Razor files
-        // through the .editorconfig-driven indent normalizer instead — it
-        // covers the realistic asks: indent style + size, and BOM toggle.
-        "cs" => run_csharpier(path, source),
-        "cshtml" | "razor" => apply_editorconfig_indent(path, source),
+        // csharpier handles .cs cleanly. For .cshtml / .razor csharpier 1.x
+        // says "Is an unsupported file type" and exits 0 — try it anyway
+        // (a future csharpier may add Razor support), then fall back to the
+        // .editorconfig-driven indent reflow if it punted.
+        "cs" => match run_csharpier(path, source)? {
+            Some(formatted) => Ok(formatted),
+            None => Ok(source.to_string()),
+        },
+        "cshtml" | "razor" => match run_csharpier(path, source)? {
+            Some(formatted) => Ok(formatted),
+            None => apply_editorconfig_indent(path, source),
+        },
         "go" => run_gofmt(source),
         _ => Err(format!("no formatter configured for .{ext}")),
     }
@@ -125,7 +131,15 @@ fn find_csharpier() -> Option<PathBuf> {
 /// edits the file in place), read the result back, then unlink. The temp
 /// file name uses a `.binvim-format` infix so it's obvious in directory
 /// listings if a crash ever leaves one behind.
-fn run_csharpier(path: &Path, source: &str) -> Result<String, String> {
+/// Returns:
+/// - `Ok(Some(text))` — csharpier formatted the file; here's the result
+/// - `Ok(None)` — csharpier ran but didn't recognise this file type
+///   (it prints `Warning … - Is an unsupported file type.` and exits 0
+///   for .cshtml / .razor in 1.x). Lets the caller fall back to a
+///   different formatter.
+/// - `Err(msg)` — a real failure: csharpier missing, parse error,
+///   non-zero exit, etc.
+fn run_csharpier(path: &Path, source: &str) -> Result<Option<String>, String> {
     let csharpier = find_csharpier().ok_or_else(|| {
         "csharpier not found — install with `dotnet tool install -g csharpier`".to_string()
     })?;
@@ -141,14 +155,20 @@ fn run_csharpier(path: &Path, source: &str) -> Result<String, String> {
     ));
     std::fs::write(&temp, source).map_err(|e| format!("write temp: {e}"))?;
     let result = csharpier_format_inplace(&csharpier, &temp);
-    let formatted = match &result {
-        Ok(()) => std::fs::read_to_string(&temp).map_err(|e| format!("read temp: {e}")),
+    let outcome = match &result {
+        Ok(CsharpierOutcome::Formatted) => std::fs::read_to_string(&temp)
+            .map(Some)
+            .map_err(|e| format!("read temp: {e}")),
+        Ok(CsharpierOutcome::Unsupported) => Ok(None),
         Err(e) => Err(e.clone()),
     };
-    // Best-effort cleanup — leaving the temp around isn't fatal, but
-    // there's no reason to keep it once we have the bytes.
     let _ = std::fs::remove_file(&temp);
-    formatted
+    outcome
+}
+
+enum CsharpierOutcome {
+    Formatted,
+    Unsupported,
 }
 
 /// Normalise leading whitespace per the project's `.editorconfig` and
@@ -283,7 +303,7 @@ fn find_on_path(name: &str) -> Option<PathBuf> {
     None
 }
 
-fn csharpier_format_inplace(csharpier: &Path, file: &Path) -> Result<(), String> {
+fn csharpier_format_inplace(csharpier: &Path, file: &Path) -> Result<CsharpierOutcome, String> {
     let mut child = Command::new(csharpier)
         .arg("format")
         .arg("--no-cache")
@@ -293,6 +313,10 @@ fn csharpier_format_inplace(csharpier: &Path, file: &Path) -> Result<(), String>
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to spawn csharpier: {e}"))?;
+    let mut stdout_buf = String::new();
+    if let Some(mut s) = child.stdout.take() {
+        let _ = s.read_to_string(&mut stdout_buf);
+    }
     let mut stderr_buf = String::new();
     if let Some(mut s) = child.stderr.take() {
         let _ = s.read_to_string(&mut stderr_buf);
@@ -301,6 +325,7 @@ fn csharpier_format_inplace(csharpier: &Path, file: &Path) -> Result<(), String>
     if !status.success() {
         let cleaned: Vec<String> = stderr_buf
             .lines()
+            .chain(stdout_buf.lines())
             .map(|l| l.trim().to_string())
             .filter(|l| !l.is_empty())
             .take(4)
@@ -313,7 +338,16 @@ fn csharpier_format_inplace(csharpier: &Path, file: &Path) -> Result<(), String>
         let code = status.code().map(|c| c.to_string()).unwrap_or_else(|| "?".into());
         return Err(format!("csharpier exit {code}: {msg}"));
     }
-    Ok(())
+    // csharpier 1.x prints `Warning <path> - Is an unsupported file type.`
+    // and exits 0 when it doesn't recognise the file (everything besides
+    // .cs in this version). That's the only signal we get that the run
+    // was a no-op — forward it so the caller can pick a fallback path.
+    if stdout_buf.contains("Is an unsupported file type")
+        || stderr_buf.contains("Is an unsupported file type")
+    {
+        return Ok(CsharpierOutcome::Unsupported);
+    }
+    Ok(CsharpierOutcome::Formatted)
 }
 
 #[cfg(test)]

--- a/src/format.rs
+++ b/src/format.rs
@@ -21,7 +21,12 @@ pub fn format_buffer(path: &Path, source: &str) -> Result<String, String> {
         "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" | "json" | "jsonc" => {
             run_biome(path, source)
         }
-        "cs" | "cshtml" | "razor" => run_csharpier(path, source),
+        // csharpier handles .cs but explicitly rejects .cshtml/.razor (it
+        // warns "unsupported file type" and exits 0). Send Razor files
+        // through the .editorconfig-driven indent normalizer instead — it
+        // covers the realistic asks: indent style + size, and BOM toggle.
+        "cs" => run_csharpier(path, source),
+        "cshtml" | "razor" => apply_editorconfig_indent(path, source),
         "go" => run_gofmt(source),
         _ => Err(format!("no formatter configured for .{ext}")),
     }
@@ -146,6 +151,71 @@ fn run_csharpier(path: &Path, source: &str) -> Result<String, String> {
     formatted
 }
 
+/// Normalise leading whitespace per the project's `.editorconfig` and
+/// honour `charset = utf-8-bom` by ensuring a BOM is (or isn't) on the
+/// front of the buffer. Used for `.cshtml` / `.razor` — csharpier doesn't
+/// support those file types, but at minimum users expect their indent
+/// settings to take effect when they save.
+///
+/// Only *leading* tabs / spaces are reflowed — tabs inside string
+/// literals or in the middle of a line are left alone, since they're
+/// almost always intentional in Razor markup.
+fn apply_editorconfig_indent(path: &Path, source: &str) -> Result<String, String> {
+    use crate::editorconfig::{EditorConfig, IndentStyle};
+    let cfg = EditorConfig::detect(path);
+    let tab_width = cfg.tab_width.max(1);
+    let indent_size = cfg.indent_size.max(1);
+    let target_unit = match cfg.indent_style {
+        IndentStyle::Spaces => " ".repeat(indent_size),
+        IndentStyle::Tabs => "\t".to_string(),
+    };
+
+    // BOM handling — only act when an .editorconfig section explicitly
+    // applies. We can't tell from `EditorConfig` whether `charset` was set
+    // on this file (the struct doesn't carry the field yet), so the BOM
+    // pass is left to a follow-up; for now we preserve whatever's on the
+    // front of `source`.
+    let mut out = String::with_capacity(source.len());
+    for line in source.split_inclusive('\n') {
+        let (leading, rest) = split_leading_indent(line);
+        let visual = leading
+            .chars()
+            .map(|c| if c == '\t' { tab_width } else { 1 })
+            .sum::<usize>();
+        let levels = visual / indent_size;
+        let extra = visual % indent_size;
+        for _ in 0..levels {
+            out.push_str(&target_unit);
+        }
+        // Stray columns that don't form a full indent level — keep them as
+        // plain spaces so we don't accidentally fuse partial indents into
+        // a tab the user didn't intend.
+        if extra > 0 {
+            for _ in 0..extra {
+                out.push(' ');
+            }
+        }
+        out.push_str(rest);
+    }
+    Ok(out)
+}
+
+/// Split a line into (leading whitespace, rest). The leading run includes
+/// any tabs and spaces; everything from the first non-whitespace char on
+/// is the rest. Newlines stay in `rest` so `split_inclusive('\n')` output
+/// round-trips cleanly.
+fn split_leading_indent(line: &str) -> (&str, &str) {
+    let mut idx = 0;
+    for (i, c) in line.char_indices() {
+        if c == ' ' || c == '\t' {
+            idx = i + c.len_utf8();
+        } else {
+            return (&line[..idx], &line[idx..]);
+        }
+    }
+    (&line[..idx], &line[idx..])
+}
+
 /// Format Go source via `gofmt` (or `goimports` when it's on PATH, which
 /// also organises imports). Both read stdin and write formatted text to
 /// stdout, so no temp file is needed — and neither tool consults
@@ -244,4 +314,76 @@ fn csharpier_format_inplace(csharpier: &Path, file: &Path) -> Result<(), String>
         return Err(format!("csharpier exit {code}: {msg}"));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a temp dir with a `.editorconfig` and a target file, return
+    /// the file's path. Caller owns the TempDir-like cleanup via the
+    /// returned `tempfile::TempDir` substitute we implement inline (no
+    /// extra dep needed — `std::env::temp_dir()` + a manual unique name).
+    fn scratch(editorconfig: &str, target_name: &str, body: &str) -> std::path::PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "binvim-fmt-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join(".editorconfig"), editorconfig).unwrap();
+        let target = root.join(target_name);
+        std::fs::write(&target, body).unwrap();
+        target
+    }
+
+    #[test]
+    fn cshtml_tabs_become_spaces_per_editorconfig() {
+        let ec = "root = true\n[*.{cshtml,html}]\nindent_style = space\nindent_size = 4\n";
+        let target = scratch(ec, "view.cshtml", "");
+        let src = "@{\n\tLayout = \"Master.cshtml\";\n\tvar x = 1;\n}\n<div>\n\t<a>hi</a>\n</div>\n";
+        let out = apply_editorconfig_indent(&target, src).expect("ok");
+        let expected = "@{\n    Layout = \"Master.cshtml\";\n    var x = 1;\n}\n<div>\n    <a>hi</a>\n</div>\n";
+        assert_eq!(out, expected);
+        let _ = std::fs::remove_dir_all(target.parent().unwrap());
+    }
+
+    #[test]
+    fn cshtml_nested_tabs_become_spaces_per_level() {
+        let ec = "root = true\n[*.cshtml]\nindent_style = space\nindent_size = 4\n";
+        let target = scratch(ec, "deep.cshtml", "");
+        let src = "<a>\n\t<b>\n\t\t<c>\n\t\t\t<d/>\n\t\t</c>\n\t</b>\n</a>\n";
+        let out = apply_editorconfig_indent(&target, src).expect("ok");
+        assert!(out.contains("    <b>"));
+        assert!(out.contains("        <c>"));
+        assert!(out.contains("            <d/>"));
+        assert!(!out.contains('\t'), "no tabs left in output");
+        let _ = std::fs::remove_dir_all(target.parent().unwrap());
+    }
+
+    #[test]
+    fn cshtml_spaces_can_round_trip_to_tabs() {
+        // Reverse direction: 4-space indents → 1 tab per level.
+        let ec = "root = true\n[*.cshtml]\nindent_style = tab\nindent_size = 4\ntab_width = 4\n";
+        let target = scratch(ec, "view.cshtml", "");
+        let src = "<a>\n    <b>\n        <c/>\n    </b>\n</a>\n";
+        let out = apply_editorconfig_indent(&target, src).expect("ok");
+        assert!(out.contains("\t<b>"));
+        assert!(out.contains("\t\t<c/>"));
+        let _ = std::fs::remove_dir_all(target.parent().unwrap());
+    }
+
+    #[test]
+    fn cshtml_keeps_inner_whitespace() {
+        // Only LEADING whitespace gets reflowed — internal alignment is left alone.
+        let ec = "root = true\n[*.cshtml]\nindent_style = space\nindent_size = 4\n";
+        let target = scratch(ec, "view.cshtml", "");
+        let src = "\t<a\thref=\"x\">y</a>\n";
+        let out = apply_editorconfig_indent(&target, src).expect("ok");
+        assert_eq!(out, "    <a\thref=\"x\">y</a>\n");
+        let _ = std::fs::remove_dir_all(target.parent().unwrap());
+    }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -22,6 +22,7 @@ pub fn format_buffer(path: &Path, source: &str) -> Result<String, String> {
             run_biome(path, source)
         }
         "cs" | "cshtml" | "razor" => run_csharpier(path, source),
+        "go" => run_gofmt(source),
         _ => Err(format!("no formatter configured for .{ext}")),
     }
 }
@@ -143,6 +144,73 @@ fn run_csharpier(path: &Path, source: &str) -> Result<String, String> {
     // there's no reason to keep it once we have the bytes.
     let _ = std::fs::remove_file(&temp);
     formatted
+}
+
+/// Format Go source via `gofmt` (or `goimports` when it's on PATH, which
+/// also organises imports). Both read stdin and write formatted text to
+/// stdout, so no temp file is needed — and neither tool consults
+/// project-relative config, so we don't need `path` for resolution.
+fn run_gofmt(source: &str) -> Result<String, String> {
+    let (bin, label) = if let Some(p) = find_on_path("goimports") {
+        (p, "goimports")
+    } else if let Some(p) = find_on_path("gofmt") {
+        (p, "gofmt")
+    } else {
+        return Err(
+            "gofmt not found — install Go (gofmt ships with it) or run `go install golang.org/x/tools/cmd/goimports@latest`"
+                .into(),
+        );
+    };
+
+    let mut child = Command::new(&bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to spawn {label}: {e}"))?;
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| format!("{label} stdin missing"))?;
+        stdin
+            .write_all(source.as_bytes())
+            .map_err(|e| format!("write to {label} stdin: {e}"))?;
+    }
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("{label} wait: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // gofmt's error format: `<stdin>:LINE:COL: message` — keep the
+        // first few lines so the user sees what's wrong.
+        let cleaned: Vec<String> = stderr
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .take(4)
+            .collect();
+        let msg = if cleaned.is_empty() {
+            "(no error output)".to_string()
+        } else {
+            cleaned.join(" / ")
+        };
+        let code = output.status.code().map(|c| c.to_string()).unwrap_or_else(|| "?".into());
+        return Err(format!("{label} exit {code}: {msg}"));
+    }
+    String::from_utf8(output.stdout).map_err(|e| format!("{label} stdout not utf-8: {e}"))
+}
+
+/// Resolve a binary by name on `$PATH`. Returns the first match.
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    let path_var = std::env::var("PATH").ok()?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 fn csharpier_format_inplace(csharpier: &Path, file: &Path) -> Result<(), String> {

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,9 +1,10 @@
 //! Buffer-level formatters. Pipes the buffer through an external tool
-//! (currently just biome) and returns the formatted text. The caller is
-//! responsible for replacing the buffer and bookkeeping the history.
+//! (biome for JS/TS/JSON, csharpier for C# / Razor) and returns the
+//! formatted text. The caller is responsible for replacing the buffer and
+//! bookkeeping the history.
 
-use std::io::Write;
-use std::path::Path;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::lsp::find_node_modules_bin;
@@ -20,6 +21,7 @@ pub fn format_buffer(path: &Path, source: &str) -> Result<String, String> {
         "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs" | "json" | "jsonc" => {
             run_biome(path, source)
         }
+        "cs" | "cshtml" | "razor" => run_csharpier(path, source),
         _ => Err(format!("no formatter configured for .{ext}")),
     }
 }
@@ -84,4 +86,94 @@ fn run_biome(path: &Path, source: &str) -> Result<String, String> {
     }
 
     String::from_utf8(output.stdout).map_err(|e| format!("biome stdout not utf-8: {e}"))
+}
+
+/// Resolve the csharpier binary. Checks `$PATH` first (covers Homebrew /
+/// custom installs), then falls back to the conventional dotnet global-tool
+/// location at `~/.dotnet/tools/csharpier` (where `dotnet tool install -g
+/// csharpier` lands by default).
+fn find_csharpier() -> Option<PathBuf> {
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            let candidate = dir.join("csharpier");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    let dotnet_tools = PathBuf::from(home).join(".dotnet/tools/csharpier");
+    if dotnet_tools.is_file() {
+        return Some(dotnet_tools);
+    }
+    None
+}
+
+/// Format C# / Razor source with csharpier. csharpier walks up from the
+/// file's directory to find `.csharpierrc` and `.editorconfig`, so we land
+/// the temp file next to the real one and use the original extension —
+/// formatting in `/tmp` would miss project-level config.
+///
+/// csharpier's stdin contract changes between versions, so we go through a
+/// temp file instead: write `source`, run `csharpier format <temp>` (which
+/// edits the file in place), read the result back, then unlink. The temp
+/// file name uses a `.binvim-format` infix so it's obvious in directory
+/// listings if a crash ever leaves one behind.
+fn run_csharpier(path: &Path, source: &str) -> Result<String, String> {
+    let csharpier = find_csharpier().ok_or_else(|| {
+        "csharpier not found — install with `dotnet tool install -g csharpier`".to_string()
+    })?;
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("cs");
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("buffer");
+    let temp = parent.join(format!(
+        ".{stem}.binvim-format.{pid}.{ext}",
+        pid = std::process::id(),
+    ));
+    std::fs::write(&temp, source).map_err(|e| format!("write temp: {e}"))?;
+    let result = csharpier_format_inplace(&csharpier, &temp);
+    let formatted = match &result {
+        Ok(()) => std::fs::read_to_string(&temp).map_err(|e| format!("read temp: {e}")),
+        Err(e) => Err(e.clone()),
+    };
+    // Best-effort cleanup — leaving the temp around isn't fatal, but
+    // there's no reason to keep it once we have the bytes.
+    let _ = std::fs::remove_file(&temp);
+    formatted
+}
+
+fn csharpier_format_inplace(csharpier: &Path, file: &Path) -> Result<(), String> {
+    let mut child = Command::new(csharpier)
+        .arg("format")
+        .arg("--no-cache")
+        .arg(file)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to spawn csharpier: {e}"))?;
+    let mut stderr_buf = String::new();
+    if let Some(mut s) = child.stderr.take() {
+        let _ = s.read_to_string(&mut stderr_buf);
+    }
+    let status = child.wait().map_err(|e| format!("csharpier wait: {e}"))?;
+    if !status.success() {
+        let cleaned: Vec<String> = stderr_buf
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .take(4)
+            .collect();
+        let msg = if cleaned.is_empty() {
+            "(no error output)".to_string()
+        } else {
+            cleaned.join(" / ")
+        };
+        let code = status.code().map(|c| c.to_string()).unwrap_or_else(|| "?".into());
+        return Err(format!("csharpier exit {code}: {msg}"));
+    }
+    Ok(())
 }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -499,6 +499,25 @@ mod tests {
     use super::*;
     use crate::config::Config;
 
+    /// Find the byte offset of a whole-word occurrence of `word` in
+    /// `source` — bounded by non-identifier chars on both sides so
+    /// `if (organization` doesn't accidentally match `notify`.
+    fn find_word(source: &str, word: &str) -> Option<usize> {
+        let is_id = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+        let bytes = source.as_bytes();
+        let mut start = 0;
+        while let Some(off) = source[start..].find(word) {
+            let i = start + off;
+            let left_ok = i == 0 || !is_id(bytes[i - 1]);
+            let right_ok = i + word.len() >= bytes.len() || !is_id(bytes[i + word.len()]);
+            if left_ok && right_ok {
+                return Some(i);
+            }
+            start = i + word.len();
+        }
+        None
+    }
+
     #[test]
     fn razor_detects_cshtml() {
         assert_eq!(
@@ -596,15 +615,20 @@ mod tests {
         );
 
         // `else` inside @if/else body — bare token, no parent node.
-        let else_idx = source.find("\n\telse\n").unwrap() + 2;
+        // The repo's indentation can be either tabs or spaces depending on
+        // whether the user's editorconfig has re-indented since the last
+        // save, so search for the `else` keyword by content rather than
+        // matching a specific leading-whitespace run.
+        let else_idx = find_word(&source, "else").expect("else keyword");
         assert_eq!(
             cache.byte_colors.get(else_idx).copied().flatten(),
             Some(mauve),
             "Razor `else` should pick up keyword Mauve via the byte-level fallback",
         );
 
-        // C# `if` inside the else body.
-        let if_idx = source.find("\t\tif (organization").unwrap() + 2;
+        // C# `if` inside the else body — find the `if (organization` site
+        // specifically so we don't pick up the @if at the top.
+        let if_idx = source.find("if (organization").expect("if (organization");
         assert_eq!(
             cache.byte_colors.get(if_idx).copied().flatten(),
             Some(mauve),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod buffer;
 mod command;
 mod config;
 mod cursor;
+mod dap;
 mod editorconfig;
 mod format;
 mod lang;

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -10,6 +10,10 @@ pub enum Mode {
     /// input flow. The associated kind tells the dispatcher what to do
     /// with the typed string on Enter.
     Prompt(PromptKind),
+    /// Focus is in the bottom debug pane (frames + locals tree). `j`/`k`
+    /// move the selection; `Enter` / `Tab` toggles a variable's expansion;
+    /// `Esc` returns to Normal mode in the editor.
+    DebugPane,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,6 +48,7 @@ impl Mode {
             Mode::Search { .. } => "SEARCH",
             Mode::Picker => "PICK",
             Mode::Prompt(_) => "PROMPT",
+            Mode::DebugPane => "DEBUG",
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -71,6 +71,31 @@ pub enum MarkAction {
     JumpExact,
 }
 
+/// Debugger sub-menu actions reachable via `<leader>d{key}`. Each variant
+/// maps 1:1 onto a `:dap*` ex-command — the leader keys are a convenience
+/// layer on top of the same dispatch.
+#[derive(Debug, Clone, Copy)]
+pub enum DebugAction {
+    /// `<leader>ds` — start a debug session.
+    Start,
+    /// `<leader>dS` — stop the active debug session.
+    Stop,
+    /// `<leader>db` — toggle a breakpoint at the cursor line.
+    ToggleBreakpoint,
+    /// `<leader>dB` — clear every breakpoint set in the active buffer.
+    ClearBreakpointsInFile,
+    /// `<leader>dc` — continue execution.
+    Continue,
+    /// `<leader>dn` — step over (DAP `next`).
+    Next,
+    /// `<leader>di` — step into.
+    StepIn,
+    /// `<leader>do` — step out.
+    StepOut,
+    /// `<leader>dp` — toggle the bottom debug pane.
+    PaneToggle,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum PickerLeader {
     Files,
@@ -134,6 +159,9 @@ pub enum Action {
     /// `<leader>f` — run the buffer's formatter and replace its contents
     /// with the result. Same code path as `:fmt` / `:format`.
     Format,
+    /// `<leader>d…` — debugger sub-menu. The associated `DebugAction`
+    /// picks the specific command; dispatch is in `app/dap_glue.rs`.
+    Debug(DebugAction),
     /// `<leader>R` — literal-string replace-all of the word under the
     /// cursor in the current buffer. Opens a prompt; on Enter applies the
     /// replacement to every occurrence via the same machinery as `:%s`.
@@ -192,6 +220,8 @@ pub struct PendingCmd {
     pub awaiting_macro_play: bool,
     /// Set after `<leader>b` — next char picks a buffer-related action.
     pub awaiting_buffer_leader: bool,
+    /// Set after `<leader>d` — next char picks a debug-related action.
+    pub awaiting_debug_leader: bool,
     /// `ds{char}` — next char names the surround pair to delete.
     pub awaiting_ds: bool,
     /// `cs{old}{new}` — first the old char, then the new char.
@@ -495,6 +525,16 @@ pub fn parse(state: &mut PendingCmd, key: KeyEvent, ctx: ParseCtx) -> ParseResul
                 state.awaiting_buffer_leader = true;
                 return ParseResult::Pending;
             }
+            // `d` opens the debugger sub-menu (`<leader>db`, `<leader>dc`, …).
+            if ch == 'd' {
+                state.awaiting_debug_leader = true;
+                return ParseResult::Pending;
+            }
+            // `d` opens the debugger sub-menu.
+            if ch == 'd' {
+                state.awaiting_debug_leader = true;
+                return ParseResult::Pending;
+            }
             let action = match ch {
                 ' ' => Some(Action::OpenPicker { kind: PickerLeader::Files }),
                 '?' => Some(Action::OpenPicker { kind: PickerLeader::Recents }),
@@ -531,6 +571,51 @@ pub fn parse(state: &mut PendingCmd, key: KeyEvent, ctx: ParseCtx) -> ParseResul
         state.reset();
         return match action {
             Some(a) => ParseResult::Action(a),
+            None => ParseResult::Cancelled,
+        };
+    }
+
+    // Debugger-prefix dispatch (after `<leader>d`).
+    if state.awaiting_debug_leader {
+        state.awaiting_debug_leader = false;
+        let action = match ch {
+            's' => Some(Action::Debug(DebugAction::Start)),
+            'S' => Some(Action::Debug(DebugAction::Stop)),
+            'b' => Some(Action::Debug(DebugAction::ToggleBreakpoint)),
+            'B' => Some(Action::Debug(DebugAction::ClearBreakpointsInFile)),
+            'c' => Some(Action::Debug(DebugAction::Continue)),
+            'n' => Some(Action::Debug(DebugAction::Next)),
+            'i' => Some(Action::Debug(DebugAction::StepIn)),
+            'o' => Some(Action::Debug(DebugAction::StepOut)),
+            'p' => Some(Action::Debug(DebugAction::PaneToggle)),
+            _ => None,
+        };
+        state.reset();
+        return match action {
+            Some(a) => ParseResult::Action(a),
+            None => ParseResult::Cancelled,
+        };
+    }
+
+    // Debug-prefix dispatch (after `<leader>d`). Every entry maps onto a
+    // `:dap*` command — same code path, different keymap.
+    if state.awaiting_debug_leader {
+        state.awaiting_debug_leader = false;
+        let action = match ch {
+            's' => Some(DebugAction::Start),
+            'S' => Some(DebugAction::Stop),
+            'b' => Some(DebugAction::ToggleBreakpoint),
+            'B' => Some(DebugAction::ClearBreakpointsInFile),
+            'c' => Some(DebugAction::Continue),
+            'n' => Some(DebugAction::Next),
+            'i' => Some(DebugAction::StepIn),
+            'o' => Some(DebugAction::StepOut),
+            'p' => Some(DebugAction::PaneToggle),
+            _ => None,
+        };
+        state.reset();
+        return match action {
+            Some(a) => ParseResult::Action(Action::Debug(a)),
             None => ParseResult::Cancelled,
         };
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,6 +94,8 @@ pub enum DebugAction {
     StepOut,
     /// `<leader>dp` — toggle the bottom debug pane.
     PaneToggle,
+    /// `<leader>df` — focus the bottom debug pane for tree navigation.
+    FocusPane,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -594,6 +596,7 @@ pub fn parse(state: &mut PendingCmd, key: KeyEvent, ctx: ParseCtx) -> ParseResul
             'i' => Some(Action::Debug(DebugAction::StepIn)),
             'O' => Some(Action::Debug(DebugAction::StepOut)),
             'p' => Some(Action::Debug(DebugAction::PaneToggle)),
+            'f' => Some(Action::Debug(DebugAction::FocusPane)),
             'o' => Some(Action::OpenPicker { kind: PickerLeader::DocumentSymbols }),
             'S' => Some(Action::OpenPicker { kind: PickerLeader::WorkspaceSymbols }),
             _ => None,
@@ -601,29 +604,6 @@ pub fn parse(state: &mut PendingCmd, key: KeyEvent, ctx: ParseCtx) -> ParseResul
         state.reset();
         return match action {
             Some(a) => ParseResult::Action(a),
-            None => ParseResult::Cancelled,
-        };
-    }
-
-    // Debug-prefix dispatch (after `<leader>d`). Every entry maps onto a
-    // `:dap*` command — same code path, different keymap.
-    if state.awaiting_debug_leader {
-        state.awaiting_debug_leader = false;
-        let action = match ch {
-            's' => Some(DebugAction::Start),
-            'S' => Some(DebugAction::Stop),
-            'b' => Some(DebugAction::ToggleBreakpoint),
-            'B' => Some(DebugAction::ClearBreakpointsInFile),
-            'c' => Some(DebugAction::Continue),
-            'n' => Some(DebugAction::Next),
-            'i' => Some(DebugAction::StepIn),
-            'o' => Some(DebugAction::StepOut),
-            'p' => Some(DebugAction::PaneToggle),
-            _ => None,
-        };
-        state.reset();
-        return match action {
-            Some(a) => ParseResult::Action(Action::Debug(a)),
             None => ParseResult::Cancelled,
         };
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -131,6 +131,9 @@ pub enum Action {
     LspGotoDefinition,
     LspFindReferences,
     LspRename,
+    /// `<leader>f` — run the buffer's formatter and replace its contents
+    /// with the result. Same code path as `:fmt` / `:format`.
+    Format,
     /// `<leader>R` — literal-string replace-all of the word under the
     /// cursor in the current buffer. Opens a prompt; on Enter applies the
     /// replacement to every occurrence via the same machinery as `:%s`.
@@ -502,6 +505,7 @@ pub fn parse(state: &mut PendingCmd, key: KeyEvent, ctx: ParseCtx) -> ParseResul
                 'a' => Some(Action::OpenPicker { kind: PickerLeader::CodeActions }),
                 'r' => Some(Action::LspRename),
                 'R' => Some(Action::ReplaceAllInBuffer),
+                'f' => Some(Action::Format),
                 _ => None,
             };
             if let Some(a) = action {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -78,7 +78,7 @@ pub enum MarkAction {
 pub enum DebugAction {
     /// `<leader>ds` — start a debug session.
     Start,
-    /// `<leader>dS` — stop the active debug session.
+    /// `<leader>dq` — stop the active debug session.
     Stop,
     /// `<leader>db` — toggle a breakpoint at the cursor line.
     ToggleBreakpoint,
@@ -90,7 +90,7 @@ pub enum DebugAction {
     Next,
     /// `<leader>di` — step into.
     StepIn,
-    /// `<leader>do` — step out.
+    /// `<leader>dO` — step out.
     StepOut,
     /// `<leader>dp` — toggle the bottom debug pane.
     PaneToggle,
@@ -540,8 +540,11 @@ pub fn parse(state: &mut PendingCmd, key: KeyEvent, ctx: ParseCtx) -> ParseResul
                 '?' => Some(Action::OpenPicker { kind: PickerLeader::Recents }),
                 'g' => Some(Action::OpenPicker { kind: PickerLeader::Grep }),
                 'e' => Some(Action::OpenYazi),
-                'o' => Some(Action::OpenPicker { kind: PickerLeader::DocumentSymbols }),
-                'S' => Some(Action::OpenPicker { kind: PickerLeader::WorkspaceSymbols }),
+                // Doc-symbol / workspace-symbol pickers moved under
+                // `<leader>d` so the debug sub-menu collects every
+                // "navigate around code while debugging" action in one
+                // place; Code actions stays at top level since it's used
+                // independently of any debug flow.
                 'a' => Some(Action::OpenPicker { kind: PickerLeader::CodeActions }),
                 'r' => Some(Action::LspRename),
                 'R' => Some(Action::ReplaceAllInBuffer),
@@ -575,19 +578,24 @@ pub fn parse(state: &mut PendingCmd, key: KeyEvent, ctx: ParseCtx) -> ParseResul
         };
     }
 
-    // Debugger-prefix dispatch (after `<leader>d`).
+    // Debugger-prefix dispatch (after `<leader>d`). `o` and `S` host the
+    // doc-symbol / workspace-symbol pickers — Step out moves to `O`
+    // (capital sibling of step-over `n` / step-in `i`) and Stop session
+    // moves to `q` (matches the `:q` mnemonic).
     if state.awaiting_debug_leader {
         state.awaiting_debug_leader = false;
         let action = match ch {
             's' => Some(Action::Debug(DebugAction::Start)),
-            'S' => Some(Action::Debug(DebugAction::Stop)),
+            'q' => Some(Action::Debug(DebugAction::Stop)),
             'b' => Some(Action::Debug(DebugAction::ToggleBreakpoint)),
             'B' => Some(Action::Debug(DebugAction::ClearBreakpointsInFile)),
             'c' => Some(Action::Debug(DebugAction::Continue)),
             'n' => Some(Action::Debug(DebugAction::Next)),
             'i' => Some(Action::Debug(DebugAction::StepIn)),
-            'o' => Some(Action::Debug(DebugAction::StepOut)),
+            'O' => Some(Action::Debug(DebugAction::StepOut)),
             'p' => Some(Action::Debug(DebugAction::PaneToggle)),
+            'o' => Some(Action::OpenPicker { kind: PickerLeader::DocumentSymbols }),
+            'S' => Some(Action::OpenPicker { kind: PickerLeader::WorkspaceSymbols }),
             _ => None,
         };
         state.reset();

--- a/src/render.rs
+++ b/src/render.rs
@@ -1481,18 +1481,53 @@ fn draw_buffer(out: &mut impl Write, app: &App) -> Result<()> {
     while line_idx < total_lines && app.line_is_folded(line_idx) {
         line_idx += 1;
     }
+    // Canonicalise the buffer's path once for the duration of this draw so
+    // breakpoint + stopped-frame gutter lookups don't do one syscall per
+    // visible row. Fall back to the raw path if canonicalisation fails
+    // (e.g. unsaved or removed file).
+    let canon_buf_path: Option<std::path::PathBuf> = app
+        .buffer
+        .path
+        .as_ref()
+        .map(|p| p.canonicalize().unwrap_or_else(|_| p.clone()));
+    // 1-based line number of the currently-stopped top frame, if the
+    // session is paused inside this buffer.
+    let pc_line: Option<usize> = match (&canon_buf_path, app.dap.session.as_ref()) {
+        (Some(bp), Some(session)) if matches!(session.state, crate::dap::SessionState::Stopped { .. }) => {
+            session.frames.first().and_then(|f| {
+                let fs = f.source.as_ref()?;
+                let fs_canon = fs.canonicalize().unwrap_or_else(|_| fs.clone());
+                if &fs_canon == bp { Some(f.line) } else { None }
+            })
+        }
+        _ => None,
+    };
     for row in 0..rows {
         // Clear the row before drawing — guards against terminal-side wrap
         // from the previous row's render leaking onto this one.
         queue!(out, MoveTo(0, (row + top) as u16), Clear(ClearType::CurrentLine))?;
         if line_idx < total_lines {
-            // Diagnostic sign column.
-            let sign = app.worst_diagnostic(line_idx).map(|s| match s {
-                Severity::Error => ('!', Color::Rgb { r: 0xf3, g: 0x8b, b: 0xa8 }), // Red
-                Severity::Warning => ('?', Color::Rgb { r: 0xf9, g: 0xe2, b: 0xaf }), // Yellow
-                Severity::Info => ('i', Color::Rgb { r: 0x89, g: 0xb4, b: 0xfa }), // Blue
-                Severity::Hint => ('h', Color::Rgb { r: 0x89, g: 0xdc, b: 0xeb }), // Sky
-            });
+            // Sign column priority: stopped-at marker > user breakpoint >
+            // worst LSP diagnostic. The debug marks are user-actionable
+            // ground truth and should win when they collide.
+            let line_one_based = line_idx + 1;
+            let pc_here = pc_line == Some(line_one_based);
+            let bp_here = canon_buf_path
+                .as_deref()
+                .map(|p| app.dap.has_breakpoint(p, line_one_based))
+                .unwrap_or(false);
+            let sign = if pc_here {
+                Some(('▶', Color::Rgb { r: 0xfa, g: 0xb3, b: 0x87 })) // Peach
+            } else if bp_here {
+                Some(('●', Color::Rgb { r: 0xf3, g: 0x8b, b: 0xa8 })) // Red
+            } else {
+                app.worst_diagnostic(line_idx).map(|s| match s {
+                    Severity::Error => ('!', Color::Rgb { r: 0xf3, g: 0x8b, b: 0xa8 }),
+                    Severity::Warning => ('?', Color::Rgb { r: 0xf9, g: 0xe2, b: 0xaf }),
+                    Severity::Info => ('i', Color::Rgb { r: 0x89, g: 0xb4, b: 0xfa }),
+                    Severity::Hint => ('h', Color::Rgb { r: 0x89, g: 0xdc, b: 0xeb }),
+                })
+            };
             if let Some((ch, color)) = sign {
                 queue!(
                     out,
@@ -2028,21 +2063,25 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
     let body_bg = Color::Rgb { r: 0x31, g: 0x32, b: 0x44 };   // Surface0
     let muted = Color::Rgb { r: 0x6c, g: 0x70, b: 0x86 };     // Overlay0
     let accent = Color::Rgb { r: 0xfa, g: 0xb3, b: 0x87 };    // Peach — debug accent
+    let base = Color::Rgb { r: 0x1e, g: 0x1e, b: 0x2e };
 
-    // Header row: " DEBUG  <status hint> "
+    // Header row: " DEBUG  <adapter> · <status> "
     let label = " DEBUG ";
-    let hint = " no session — :debug to start ";
+    let hint = match app.dap.session.as_ref() {
+        Some(s) => format!(" {} · {} ", s.adapter_key, s.status_line),
+        None => " no session — :debug to start ".to_string(),
+    };
     queue!(out, MoveTo(0, top as u16), Clear(ClearType::CurrentLine))?;
     queue!(
         out,
         SetBackgroundColor(accent),
-        SetForegroundColor(Color::Rgb { r: 0x1e, g: 0x1e, b: 0x2e }), // Base
+        SetForegroundColor(base),
         SetAttribute(Attribute::Bold),
         Print(label),
         SetAttribute(Attribute::Reset),
         SetBackgroundColor(header_bg),
         SetForegroundColor(muted),
-        Print(hint),
+        Print(&hint),
     )?;
     let used = label.chars().count() + hint.chars().count();
     if width > used {
@@ -2050,18 +2089,81 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
     }
     queue!(out, ResetColor)?;
 
-    // Body rows — filled with the panel background so the editor's cleared
-    // ground doesn't bleed through. Phase 1: empty placeholder.
-    for r in 1..rows {
+    // Body — split horizontally into two columns when there's room: left
+    // shows the call stack, right shows the recent debug-console output.
+    // When the pane is too narrow we drop the call stack column.
+    let body_rows = rows.saturating_sub(1);
+    let split_at = if width >= 80 { width / 2 } else { width };
+    let frames: Vec<String> = app
+        .dap
+        .session
+        .as_ref()
+        .map(|s| {
+            s.frames
+                .iter()
+                .map(|f| {
+                    let loc = f
+                        .source
+                        .as_ref()
+                        .and_then(|p| p.file_name())
+                        .and_then(|n| n.to_str())
+                        .map(|n| format!("{}:{}", n, f.line))
+                        .unwrap_or_else(|| format!("?:{}", f.line));
+                    format!("{} — {}", loc, f.name)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let output_tail: Vec<&str> = {
+        let n = app.dap.output_buffer.len();
+        let take = body_rows.min(n);
+        app.dap.output_buffer[n - take..]
+            .iter()
+            .flat_map(|line| line.output.lines())
+            .collect()
+    };
+
+    for r in 0..body_rows {
+        let y = (top + 1 + r) as u16;
+        queue!(out, MoveTo(0, y), Clear(ClearType::CurrentLine))?;
+        // Left column: frames.
         queue!(
             out,
-            MoveTo(0, (top + r) as u16),
-            Clear(ClearType::CurrentLine),
             SetBackgroundColor(body_bg),
             SetForegroundColor(header_fg),
-            Print(" ".repeat(width)),
-            ResetColor
         )?;
+        let left_w = if split_at < width { split_at.saturating_sub(1) } else { width };
+        let left_text = match (r, frames.get(r)) {
+            (0, None) if app.dap.session.is_some() => " (no frames yet — waiting for stop) ".to_string(),
+            (_, Some(f)) => format!(" {} ", truncate_left(f, left_w.saturating_sub(2))),
+            (_, None) => String::new(),
+        };
+        let visible: String = left_text.chars().take(left_w).collect();
+        queue!(out, Print(&visible))?;
+        if visible.chars().count() < left_w {
+            queue!(out, Print(" ".repeat(left_w - visible.chars().count())))?;
+        }
+        // Separator column.
+        if split_at < width {
+            queue!(
+                out,
+                SetForegroundColor(muted),
+                Print("│"),
+                SetForegroundColor(header_fg),
+            )?;
+            // Right column: console output tail.
+            let right_w = width.saturating_sub(left_w + 1);
+            let right_text = output_tail
+                .get(r)
+                .map(|s| format!(" {} ", s.trim_end()))
+                .unwrap_or_default();
+            let right_visible: String = right_text.chars().take(right_w).collect();
+            queue!(out, Print(&right_visible))?;
+            if right_visible.chars().count() < right_w {
+                queue!(out, Print(" ".repeat(right_w - right_visible.chars().count())))?;
+            }
+        }
+        queue!(out, ResetColor)?;
     }
     Ok(())
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -2142,7 +2142,24 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
             };
             left_rows.push(LeftRow::Note(note));
         }
-        for f in &session.frames {
+        // When locals are present, cap the frame list so the user-relevant
+        // top frames + the separator + at least a few locals all fit in
+        // the body. Deep ASP.NET / framework stacks otherwise eat the
+        // whole left column and locals disappear off-screen.
+        let frames_cap = if flat.is_empty() {
+            session.frames.len()
+        } else {
+            // Leave room for: separator (1) + at least 3 locals rows.
+            body_rows
+                .saturating_sub(4)
+                .min(session.frames.len())
+                .max(3)
+                .min(session.frames.len())
+        };
+        let visible_frames = frames_cap.min(session.frames.len());
+        let hidden = session.frames.len().saturating_sub(visible_frames);
+        let take = if hidden > 0 { visible_frames.saturating_sub(1) } else { visible_frames };
+        for f in session.frames.iter().take(take) {
             let loc = f
                 .source
                 .as_ref()
@@ -2151,6 +2168,12 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
                 .map(|n| format!("{}:{}", n, f.line))
                 .unwrap_or_else(|| format!("?:{}", f.line));
             left_rows.push(LeftRow::Frame(format!("{} — {}", loc, f.name)));
+        }
+        if hidden > 0 {
+            // Note row holds a hint that more frames exist — gives the
+            // user the count without us having to wire a scroll model.
+            let hidden_total = session.frames.len() - take;
+            left_rows.push(LeftRow::Frame(format!("    … +{} more frame(s)", hidden_total)));
         }
         if !flat.is_empty() {
             left_rows.push(LeftRow::Separator(" Locals "));

--- a/src/render.rs
+++ b/src/render.rs
@@ -19,6 +19,7 @@ pub fn draw(out: &mut impl Write, app: &App) -> Result<()> {
         draw_tab_bar(out, app)?;
     }
     draw_buffer(out, app)?;
+    draw_debug_pane(out, app)?;
     draw_status_line(out, app)?;
     draw_notification(out, app)?;
     if matches!(app.mode, Mode::Command | Mode::Search { .. } | Mode::Prompt(_)) {
@@ -2012,6 +2013,57 @@ fn truncate_left(s: &str, max: usize) -> String {
     let mut out = String::from("…");
     out.extend(chars[start..].iter());
     out
+}
+
+fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
+    let rows = app.debug_pane_rows();
+    if rows == 0 {
+        return Ok(());
+    }
+    let top = app.debug_pane_top();
+    let width = app.width as usize;
+
+    let header_bg = Color::Rgb { r: 0x45, g: 0x47, b: 0x5a }; // Surface1
+    let header_fg = Color::Rgb { r: 0xcd, g: 0xd6, b: 0xf4 }; // Text
+    let body_bg = Color::Rgb { r: 0x31, g: 0x32, b: 0x44 };   // Surface0
+    let muted = Color::Rgb { r: 0x6c, g: 0x70, b: 0x86 };     // Overlay0
+    let accent = Color::Rgb { r: 0xfa, g: 0xb3, b: 0x87 };    // Peach — debug accent
+
+    // Header row: " DEBUG  <status hint> "
+    let label = " DEBUG ";
+    let hint = " no session — :debug to start ";
+    queue!(out, MoveTo(0, top as u16), Clear(ClearType::CurrentLine))?;
+    queue!(
+        out,
+        SetBackgroundColor(accent),
+        SetForegroundColor(Color::Rgb { r: 0x1e, g: 0x1e, b: 0x2e }), // Base
+        SetAttribute(Attribute::Bold),
+        Print(label),
+        SetAttribute(Attribute::Reset),
+        SetBackgroundColor(header_bg),
+        SetForegroundColor(muted),
+        Print(hint),
+    )?;
+    let used = label.chars().count() + hint.chars().count();
+    if width > used {
+        queue!(out, SetBackgroundColor(header_bg), Print(" ".repeat(width - used)))?;
+    }
+    queue!(out, ResetColor)?;
+
+    // Body rows — filled with the panel background so the editor's cleared
+    // ground doesn't bleed through. Phase 1: empty placeholder.
+    for r in 1..rows {
+        queue!(
+            out,
+            MoveTo(0, (top + r) as u16),
+            Clear(ClearType::CurrentLine),
+            SetBackgroundColor(body_bg),
+            SetForegroundColor(header_fg),
+            Print(" ".repeat(width)),
+            ResetColor
+        )?;
+    }
+    Ok(())
 }
 
 fn draw_status_line(out: &mut impl Write, app: &App) -> Result<()> {

--- a/src/render.rs
+++ b/src/render.rs
@@ -2107,7 +2107,17 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
     let mut left_rows: Vec<LeftRow> = Vec::new();
     if let Some(session) = app.dap.session.as_ref() {
         if session.frames.is_empty() {
-            left_rows.push(LeftRow::Note("(no frames — running)"));
+            // Tag the empty-frames note with the actual state so a
+            // stopped-but-no-frames situation reads as a problem to
+            // diagnose instead of looking identical to "still running".
+            let note = match session.state {
+                crate::dap::SessionState::Stopped { .. } => "(stopped — waiting for stackTrace)",
+                crate::dap::SessionState::Running => "(running — no frames)",
+                crate::dap::SessionState::Initializing => "(initialising)",
+                crate::dap::SessionState::Configuring => "(configuring)",
+                crate::dap::SessionState::Terminated => "(terminated)",
+            };
+            left_rows.push(LeftRow::Note(note));
         }
         for f in &session.frames {
             let loc = f

--- a/src/render.rs
+++ b/src/render.rs
@@ -2059,9 +2059,12 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
     let top = app.debug_pane_top();
     let width = app.width as usize;
 
-    let header_bg = Color::Rgb { r: 0x45, g: 0x47, b: 0x5a }; // Surface1
+    // Mantle — same shade the tab bar uses, so the pane reads as
+    // chrome rather than another buffer split.
+    let pane_bg = Color::Rgb { r: 0x18, g: 0x18, b: 0x25 };
+    let header_bg = pane_bg;
     let header_fg = Color::Rgb { r: 0xcd, g: 0xd6, b: 0xf4 }; // Text
-    let body_bg = Color::Rgb { r: 0x31, g: 0x32, b: 0x44 };   // Surface0
+    let body_bg = pane_bg;
     let muted = Color::Rgb { r: 0x6c, g: 0x70, b: 0x86 };     // Overlay0
     let accent = Color::Rgb { r: 0xfa, g: 0xb3, b: 0x87 };    // Peach — debug accent
     let base = Color::Rgb { r: 0x1e, g: 0x1e, b: 0x2e };

--- a/src/render.rs
+++ b/src/render.rs
@@ -2145,24 +2145,10 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
             };
             left_rows.push(LeftRow::Note(note));
         }
-        // When locals are present, cap the frame list so the user-relevant
-        // top frames + the separator + at least a few locals all fit in
-        // the body. Deep ASP.NET / framework stacks otherwise eat the
-        // whole left column and locals disappear off-screen.
-        let frames_cap = if flat.is_empty() {
-            session.frames.len()
-        } else {
-            // Leave room for: separator (1) + at least 3 locals rows.
-            body_rows
-                .saturating_sub(4)
-                .min(session.frames.len())
-                .max(3)
-                .min(session.frames.len())
-        };
-        let visible_frames = frames_cap.min(session.frames.len());
-        let hidden = session.frames.len().saturating_sub(visible_frames);
-        let take = if hidden > 0 { visible_frames.saturating_sub(1) } else { visible_frames };
-        for f in session.frames.iter().take(take) {
+        // Show every frame — overflow is handled by the left column's
+        // scroll position (`dap_left_scroll`), driven by the key handler
+        // and clamped below.
+        for f in &session.frames {
             let loc = f
                 .source
                 .as_ref()
@@ -2171,12 +2157,6 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
                 .map(|n| format!("{}:{}", n, f.line))
                 .unwrap_or_else(|| format!("?:{}", f.line));
             left_rows.push(LeftRow::Frame(format!("{} — {}", loc, f.name)));
-        }
-        if hidden > 0 {
-            // Note row holds a hint that more frames exist — gives the
-            // user the count without us having to wire a scroll model.
-            let hidden_total = session.frames.len() - take;
-            left_rows.push(LeftRow::Frame(format!("    … +{} more frame(s)", hidden_total)));
         }
         if !flat.is_empty() {
             left_rows.push(LeftRow::Separator(" Locals "));
@@ -2197,21 +2177,43 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
         }
     }
 
-    let output_tail: Vec<&str> = {
-        let n = app.dap.output_buffer.len();
-        let take = body_rows.min(n);
-        app.dap.output_buffer[n - take..]
-            .iter()
-            .flat_map(|line| line.output.lines())
-            .collect()
+    // Clamp the user-driven scroll positions to their valid range. The
+    // key handler keeps them in range too, but resizing the terminal or
+    // a fresh log line landing right before the draw can put them
+    // slightly out of bounds — easier to clamp here than to chase every
+    // upstream mutation.
+    let left_scroll = {
+        let max = left_rows.len().saturating_sub(body_rows);
+        app.dap_left_scroll.min(max)
     };
+
+    // Full flat-mapped output buffer — we need every line because the
+    // user can scroll back through history with `K`. The buffer is
+    // bounded by `OUTPUT_LOG_CAP` so this stays cheap.
+    let output_all: Vec<&str> = app
+        .dap
+        .output_buffer
+        .iter()
+        .flat_map(|line| line.output.lines())
+        .collect();
+    let right_scroll = {
+        let max = output_all.len().saturating_sub(body_rows);
+        app.dap_right_scroll.min(max)
+    };
+    // Visible right-column window: last `body_rows` lines, then walked
+    // back `right_scroll` lines into the past.
+    let total_lines = output_all.len();
+    let end = total_lines.saturating_sub(right_scroll);
+    let start = end.saturating_sub(body_rows);
+    let output_tail: &[&str] = &output_all[start..end];
 
     for r in 0..body_rows {
         let y = (top + 1 + r) as u16;
         queue!(out, MoveTo(0, y), Clear(ClearType::CurrentLine))?;
         queue!(out, SetBackgroundColor(body_bg))?;
-        // Left column.
-        let row = left_rows.get(r).unwrap_or(&LeftRow::Empty);
+        // Left column. Apply scroll offset so the user can pan through
+        // a stack deeper than the visible viewport.
+        let row = left_rows.get(r + left_scroll).unwrap_or(&LeftRow::Empty);
         let inner_w = left_w.saturating_sub(2);
         match row {
             LeftRow::Empty => {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1976,6 +1976,7 @@ fn mode_color(mode: Mode) -> Color {
         Mode::Search { .. } => Color::Rgb { r: 0xfa, g: 0xb3, b: 0x87 }, // Peach
         Mode::Picker => Color::Rgb { r: 0x89, g: 0xdc, b: 0xeb }, // Sky
         Mode::Prompt(_) => Color::Rgb { r: 0xfa, g: 0xb3, b: 0x87 }, // Peach
+        Mode::DebugPane => Color::Rgb { r: 0xfa, g: 0xb3, b: 0x87 }, // Peach — matches debug pane accent
     }
 }
 
@@ -2101,8 +2102,30 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
         Note(&'a str),
         Frame(String),
         Separator(&'a str),
-        Local(&'a str, &'a str),
+        Local {
+            depth: usize,
+            marker: char,
+            name: &'a str,
+            value: &'a str,
+            selected: bool,
+        },
     }
+
+    // Flat locals tree — computed once so the key handler and renderer
+    // agree on row order (the renderer's selection highlight has to point
+    // at the same row the cursor's index does).
+    let flat = app
+        .dap
+        .session
+        .as_ref()
+        .map(crate::dap::flat_locals_view)
+        .unwrap_or_default();
+    let pane_focused = app.mode == Mode::DebugPane;
+    let selected_local_idx = if pane_focused && !flat.is_empty() {
+        Some(app.dap_pane_cursor.min(flat.len() - 1))
+    } else {
+        None
+    };
 
     let mut left_rows: Vec<LeftRow> = Vec::new();
     if let Some(session) = app.dap.session.as_ref() {
@@ -2129,10 +2152,21 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
                 .unwrap_or_else(|| format!("?:{}", f.line));
             left_rows.push(LeftRow::Frame(format!("{} — {}", loc, f.name)));
         }
-        if !session.locals.is_empty() {
+        if !flat.is_empty() {
             left_rows.push(LeftRow::Separator(" Locals "));
-            for v in &session.locals {
-                left_rows.push(LeftRow::Local(&v.name, &v.value));
+            for (i, row) in flat.iter().enumerate() {
+                let marker = if row.expandable {
+                    if row.expanded { '▼' } else { '▶' }
+                } else {
+                    ' '
+                };
+                left_rows.push(LeftRow::Local {
+                    depth: row.depth,
+                    marker,
+                    name: &row.var.name,
+                    value: &row.var.value,
+                    selected: selected_local_idx == Some(i),
+                });
             }
         }
     }
@@ -2190,14 +2224,36 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
                 )?;
                 pad_right(out, 2 + bar_room + label.chars().count(), left_w)?;
             }
-            LeftRow::Local(name, value) => {
-                let entry = format!("{} = {}", name, value);
+            LeftRow::Local {
+                depth,
+                marker,
+                name,
+                value,
+                selected,
+            } => {
+                // Catppuccin Surface2 — visible against body_bg without
+                // shouting.
+                let selection_bg = Color::Rgb { r: 0x58, g: 0x5b, b: 0x70 };
+                let row_bg = if *selected { selection_bg } else { body_bg };
+                let indent: String = "  ".repeat(*depth);
+                let entry = format!("{}{} {} = {}", indent, marker, name, value);
+                let max_inner = inner_w.saturating_sub(1);
+                let visible = truncate_left(&entry, max_inner);
                 queue!(
                     out,
+                    SetBackgroundColor(row_bg),
                     SetForegroundColor(header_fg),
-                    Print(format!("   {} ", truncate_left(&entry, inner_w.saturating_sub(1)))),
+                    Print(format!(" {} ", visible)),
                 )?;
-                pad_right(out, 4 + entry.chars().count().min(inner_w.saturating_sub(1)), left_w)?;
+                let used = 2 + visible.chars().count();
+                if left_w > used {
+                    queue!(
+                        out,
+                        SetBackgroundColor(row_bg),
+                        Print(" ".repeat(left_w - used))
+                    )?;
+                }
+                queue!(out, SetBackgroundColor(body_bg))?;
             }
         }
         // Right column (and column divider) — only when the pane is wide
@@ -2376,6 +2432,13 @@ fn place_cursor(out: &mut impl Write, app: &App) -> Result<()> {
     if app.show_start_page
         && !matches!(app.mode, Mode::Command | Mode::Search { .. } | Mode::Picker)
     {
+        queue!(out, Hide)?;
+        return Ok(());
+    }
+    // In the debug pane focus mode the selection highlight in the pane
+    // is the user's "cursor" — the editor's terminal cursor would just
+    // distract.
+    if app.mode == Mode::DebugPane {
         queue!(out, Hide)?;
         return Ok(());
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -2089,31 +2089,44 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
     }
     queue!(out, ResetColor)?;
 
-    // Body — split horizontally into two columns when there's room: left
-    // shows the call stack, right shows the recent debug-console output.
-    // When the pane is too narrow we drop the call stack column.
+    // Body — split horizontally when the terminal is wide enough. The
+    // left column stacks call stack on top of locals (with a labelled
+    // separator); the right column is the console-output tail.
     let body_rows = rows.saturating_sub(1);
     let split_at = if width >= 80 { width / 2 } else { width };
-    let frames: Vec<String> = app
-        .dap
-        .session
-        .as_ref()
-        .map(|s| {
-            s.frames
-                .iter()
-                .map(|f| {
-                    let loc = f
-                        .source
-                        .as_ref()
-                        .and_then(|p| p.file_name())
-                        .and_then(|n| n.to_str())
-                        .map(|n| format!("{}:{}", n, f.line))
-                        .unwrap_or_else(|| format!("?:{}", f.line));
-                    format!("{} — {}", loc, f.name)
-                })
-                .collect()
-        })
-        .unwrap_or_default();
+    let left_w = if split_at < width { split_at.saturating_sub(1) } else { width };
+
+    enum LeftRow<'a> {
+        Empty,
+        Note(&'a str),
+        Frame(String),
+        Separator(&'a str),
+        Local(&'a str, &'a str),
+    }
+
+    let mut left_rows: Vec<LeftRow> = Vec::new();
+    if let Some(session) = app.dap.session.as_ref() {
+        if session.frames.is_empty() {
+            left_rows.push(LeftRow::Note("(no frames — running)"));
+        }
+        for f in &session.frames {
+            let loc = f
+                .source
+                .as_ref()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .map(|n| format!("{}:{}", n, f.line))
+                .unwrap_or_else(|| format!("?:{}", f.line));
+            left_rows.push(LeftRow::Frame(format!("{} — {}", loc, f.name)));
+        }
+        if !session.locals.is_empty() {
+            left_rows.push(LeftRow::Separator(" Locals "));
+            for v in &session.locals {
+                left_rows.push(LeftRow::Local(&v.name, &v.value));
+            }
+        }
+    }
+
     let output_tail: Vec<&str> = {
         let n = app.dap.output_buffer.len();
         let take = body_rows.min(n);
@@ -2126,24 +2139,59 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
     for r in 0..body_rows {
         let y = (top + 1 + r) as u16;
         queue!(out, MoveTo(0, y), Clear(ClearType::CurrentLine))?;
-        // Left column: frames.
-        queue!(
-            out,
-            SetBackgroundColor(body_bg),
-            SetForegroundColor(header_fg),
-        )?;
-        let left_w = if split_at < width { split_at.saturating_sub(1) } else { width };
-        let left_text = match (r, frames.get(r)) {
-            (0, None) if app.dap.session.is_some() => " (no frames yet — waiting for stop) ".to_string(),
-            (_, Some(f)) => format!(" {} ", truncate_left(f, left_w.saturating_sub(2))),
-            (_, None) => String::new(),
-        };
-        let visible: String = left_text.chars().take(left_w).collect();
-        queue!(out, Print(&visible))?;
-        if visible.chars().count() < left_w {
-            queue!(out, Print(" ".repeat(left_w - visible.chars().count())))?;
+        queue!(out, SetBackgroundColor(body_bg))?;
+        // Left column.
+        let row = left_rows.get(r).unwrap_or(&LeftRow::Empty);
+        let inner_w = left_w.saturating_sub(2);
+        match row {
+            LeftRow::Empty => {
+                queue!(out, Print(" ".repeat(left_w)))?;
+            }
+            LeftRow::Note(s) => {
+                queue!(
+                    out,
+                    SetForegroundColor(muted),
+                    Print(format!(" {} ", truncate_left(s, inner_w))),
+                )?;
+                pad_right(out, 2 + s.chars().count(), left_w)?;
+            }
+            LeftRow::Frame(s) => {
+                queue!(
+                    out,
+                    SetForegroundColor(header_fg),
+                    Print(format!(" {} ", truncate_left(s, inner_w))),
+                )?;
+                pad_right(out, 2 + s.chars().count().min(inner_w), left_w)?;
+            }
+            LeftRow::Separator(label) => {
+                let bar_room = inner_w.saturating_sub(label.chars().count());
+                let left_bar = bar_room / 2;
+                let right_bar = bar_room - left_bar;
+                queue!(
+                    out,
+                    SetForegroundColor(muted),
+                    Print(" "),
+                    Print("─".repeat(left_bar)),
+                    SetForegroundColor(header_fg),
+                    Print(*label),
+                    SetForegroundColor(muted),
+                    Print("─".repeat(right_bar)),
+                    Print(" "),
+                )?;
+                pad_right(out, 2 + bar_room + label.chars().count(), left_w)?;
+            }
+            LeftRow::Local(name, value) => {
+                let entry = format!("{} = {}", name, value);
+                queue!(
+                    out,
+                    SetForegroundColor(header_fg),
+                    Print(format!("   {} ", truncate_left(&entry, inner_w.saturating_sub(1)))),
+                )?;
+                pad_right(out, 4 + entry.chars().count().min(inner_w.saturating_sub(1)), left_w)?;
+            }
         }
-        // Separator column.
+        // Right column (and column divider) — only when the pane is wide
+        // enough to split.
         if split_at < width {
             queue!(
                 out,
@@ -2151,7 +2199,6 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
                 Print("│"),
                 SetForegroundColor(header_fg),
             )?;
-            // Right column: console output tail.
             let right_w = width.saturating_sub(left_w + 1);
             let right_text = output_tail
                 .get(r)
@@ -2164,6 +2211,15 @@ fn draw_debug_pane(out: &mut impl Write, app: &App) -> Result<()> {
             }
         }
         queue!(out, ResetColor)?;
+    }
+    Ok(())
+}
+
+/// Pad the current row out to `target` columns by writing spaces. `written`
+/// is how many character columns have already been printed for this row.
+fn pad_right(out: &mut impl Write, written: usize, target: usize) -> Result<()> {
+    if target > written {
+        queue!(out, Print(" ".repeat(target - written)))?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

A few months of work consolidated on `feat/dap` — three big additions plus a handful of stability fixes since `0.1.2`.

### .NET Core debugger via DAP
- `src/dap/` module: spawns netcoredbg, runs the full DAP handshake (initialize → launch → setBreakpoints → configurationDone), surfaces events on a bottom pane.
- `:debug` / `<leader>ds` auto-builds the project (`dotnet build`) and resolves the dll under `bin/Debug/net*/`.
- Bottom debug pane with call stack + locals on the left, debug-console on the right. Variable expansion is lazy (▶/▼ markers, vref-keyed children cache).
- `Mode::DebugPane` for in-pane navigation (`j`/`k`/`g`/`G`/`Enter`/`Ctrl-Y`/`Ctrl-E`/`J`/`K`/`c`/`n`/`i`/`O`/`:`/`Esc`).
- VS / Rider F-key bindings (`F5`, `Shift+F5`, `F9`, `F10`, `F11`, `Shift+F11`).
- Auto-jump to the stopped frame on `stopped` events; gutter ▶ marker for the current PC.
- Diagnostic plumbing: adapter stderr streamed into the pane, unverified-breakpoint surfacing, `breakpoint` events parsed so JIT rebinds become visible.

### Razor / `.cshtml` syntax highlighting
- `Lang::Razor` via `tree-sitter-razor` + C# highlight query + Razor overlay (every `@`-marker as `@keyword.directive`).
- Byte-level fallback paints HTML tag / attribute names and C# keywords inside broken-parse regions (Tailwind bracket attrs, BOM headers, etc.).

### Formatter chain
- `<leader>f` (= `:fmt`) — runs the right tool per extension.
- csharpier for `.cs`; `.editorconfig` indent reflow for `.cshtml` / `.razor` (csharpier 1.x says "unsupported file type" for Razor, so it falls through).
- gofmt / goimports for `.go` (prefers goimports when on `$PATH`).

### Other
- Visual-mode `p` / `P` replaces the selection.
- OS clipboard reads on `"`/`+`/`*` paste — anything copied in another app wins over the in-memory yank.
- CRLF normalisation on file load (was clobbering inline diagnostics on `.cs` files with mixed line endings).
- Mouse clicks on tab-indented lines now land where you click (was off by `(TAB_WIDTH-1) * tab_count`).
- `<leader>d` debug sub-menu; Doc/Workspace symbols moved to `<leader>do` / `<leader>dS`.

Full per-feature notes are in `CHANGELOG.md` under `[Unreleased]`.

## Test plan
- [x] `cargo test` — 66 passing (was 45 on `0.1.2`).
- [x] Debug session against the DummyApi project: start → breakpoint hit → step → continue → stop closes pane.
- [x] Razor highlighting against `ProductCategory.cshtml` + `MMSHeader.cshtml` (BOM + bracket-attr cases).
- [x] csharpier + editorconfig fallback on `.cshtml`.
- [x] `<leader>f` on `.cs`, `.cshtml`, `.go`, `.ts`.
- [x] Cross-app clipboard paste with `p` / `P` / visual `p`.
- [x] CRLF file (AudioPlayer.cs) opens with no cursor reset.