### PR TITLE
fix: account for wide CJK chars in visual-column math

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -117,11 +117,10 @@ fn visual_col_to_char_col_with_hints(
             }
             visual += hw;
         }
-        let w = if c == '\t' {
-            crate::render::TAB_WIDTH
-        } else {
-            1
-        };
+        // Mirror of the renderer's advance: tabs expand to TAB_WIDTH cells, CJK /
+        // wide glyphs are two cells. Matching the render walk is what makes a
+        // click land on the character the user is actually pointing at.
+        let w = crate::render::char_width(c, crate::render::TAB_WIDTH);
         if visual >= visual_col {
             break;
         }
@@ -1125,8 +1124,9 @@ impl super::App {
         // buffer char column. Tabs render at `TAB_WIDTH` cols but are still
         // a single buffer char, so a naive `raw_col` calculation lands the
         // cursor several chars past tab-indented text. We replay the same
-        // width rule the renderer uses (tab = TAB_WIDTH, everything else
-        // = 1) walking the line until we've consumed `visual_col` cells.
+        // width rule the renderer uses (tab = TAB_WIDTH, everything else = its
+        // terminal display width) walking the line until we've consumed
+        // `visual_col` cells.
         let visual_col = pane_col.saturating_sub(gutter) + self.window.view_left;
         let buf_col = visual_col_to_char_col(self, buf_line, visual_col, line_len);
 
@@ -2469,6 +2469,45 @@ mod tests {
         assert_eq!(
             visual_col_to_char_col_with_hints(&b, 0, 6, 11, &[], true),
             6
+        );
+    }
+
+    #[test]
+    fn visual_col_to_char_col_wide_chars() {
+        // Regression: clicking into CJK text must land on the character
+        // the cursor cell points at, matching the 2-cell terminal width.
+        // "你好世界" — each char is 2 cells wide.
+        let b = buf("\u{4F60}\u{597D}\u{4E16}\u{754C}\n");
+        // First cell of each wide char snaps to that char.
+        assert_eq!(
+            visual_col_to_char_col_with_hints(&b, 0, 0, 4, &[], false),
+            0
+        );
+        assert_eq!(
+            visual_col_to_char_col_with_hints(&b, 0, 2, 4, &[], false),
+            1
+        );
+        assert_eq!(
+            visual_col_to_char_col_with_hints(&b, 0, 4, 4, &[], false),
+            2
+        );
+        assert_eq!(
+            visual_col_to_char_col_with_hints(&b, 0, 6, 4, &[], false),
+            3
+        );
+        // Second cell of a wide char stays on the same char.
+        assert_eq!(
+            visual_col_to_char_col_with_hints(&b, 0, 1, 4, &[], false),
+            0
+        );
+        assert_eq!(
+            visual_col_to_char_col_with_hints(&b, 0, 7, 4, &[], false),
+            3
+        );
+        // Past EOL in Normal mode clamps to the last char (col 3).
+        assert_eq!(
+            visual_col_to_char_col_with_hints(&b, 0, 40, 4, &[], false),
+            3
         );
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1041,8 +1041,8 @@ impl HoverState {
             .map(|l| match l {
                 HoverLine::Blank => 0,
                 HoverLine::Rule => 0,
-                HoverLine::Prose(s) => s.chars().count(),
-                HoverLine::Heading { text, .. } => text.chars().count(),
+                HoverLine::Prose(s) => visual_width(s),
+                HoverLine::Heading { text, .. } => visual_width(text),
                 HoverLine::Code {
                     block_idx,
                     byte_offset,
@@ -1058,18 +1058,13 @@ impl HoverState {
     }
 }
 
-/// Visible width of a string when tabs expand to TAB_WIDTH columns. Used
-/// for sizing only — the renderer does the actual tab expansion.
+/// Visible width of a string when tabs expand to TAB_WIDTH columns and CJK /
+/// other wide glyphs are two cells. Used for sizing only — the renderer does
+/// the actual tab expansion.
 fn visual_width(s: &str) -> usize {
-    let mut w = 0usize;
-    for c in s.chars() {
-        if c == '\t' {
-            w += crate::render::TAB_WIDTH;
-        } else {
-            w += 1;
-        }
-    }
-    w
+    s.chars()
+        .map(|c| crate::render::char_width(c, crate::render::TAB_WIDTH))
+        .sum()
 }
 
 /// Push one `HoverLine::Code` per source line of `collected`, or one

--- a/src/markdown_render.rs
+++ b/src/markdown_render.rs
@@ -1186,8 +1186,7 @@ pub fn visual_col_for_buffer_col(
             }
         }
         let c = chars[col];
-        let w = if c == '\t' { tab_width } else { 1 };
-        visual += w;
+        visual += crate::render::char_width(c, tab_width);
         col += 1;
     }
     visual
@@ -1228,7 +1227,7 @@ pub fn buffer_col_for_visual_col(
             }
         }
         let c = chars[col];
-        let w = if c == '\t' { tab_width } else { 1 };
+        let w = crate::render::char_width(c, tab_width);
         if visual + w > target_visual {
             return col;
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -16,6 +16,20 @@ use std::io::Write;
 
 pub const TAB_WIDTH: usize = 4;
 
+/// Terminal cell width of a character, in the renderer's far-east-aware sense:
+/// tabs expand to a caller-supplied tab stop, CJK and other wide glyphs are
+/// two cells, and control chars (which report no width) fall back to 1. The
+/// draw walk, cursor walk, click walk, markdown walk, and overlays must all
+/// use this so they agree on where a wide char starts and ends — the exact
+/// class of drift this module keeps fixed.
+pub(crate) fn char_width(c: char, tab_width: usize) -> usize {
+    if c == '\t' {
+        tab_width
+    } else {
+        unicode_width::UnicodeWidthChar::width(c).unwrap_or(1)
+    }
+}
+
 /// Reset SGR state and immediately re-apply the optional theme background so
 /// subsequent unstyled `Print` calls land on the theme bg instead of the
 /// terminal's default. When `buf_bg` is `None` (no `background` set in
@@ -869,8 +883,13 @@ fn paint_code_line(
             if written >= max_w {
                 return Ok(written);
             }
+            let cells = char_width(ch, TAB_WIDTH);
+            // `written` counts display cells (CJK/wide = 2, zero-width = 0) so
+            // the caller's width-based padding matches `widest_line()`; source
+            // text that reaches past `max_w` just over-counts and the caller's
+            // `saturating_sub` padding absorbs the straddle.
             queue!(out, SetForegroundColor(fg), Print(ch.to_string()))?;
-            written += 1;
+            written += cells;
         }
     }
     Ok(written)
@@ -5148,6 +5167,32 @@ mod tests {
     }
 
     #[test]
+    fn cursor_visual_col_walks_wide_chars_as_two_cells() {
+        // Regression: CJK / wide glyphs are two terminal cells, so the
+        // cursor's visual column must not stop short of the line end.
+        // "你" and "好" are each 2 cells wide → cursor at char col 2 (EOL)
+        // sits at visual col 4, not col 2.
+        let chars = "\u{4F60}\u{597D}".chars();
+        assert_eq!(cursor_visual_col_walk(chars.clone(), 2, &[]), 4);
+        // Cursor between the two wide chars sits at visual col 2.
+        assert_eq!(cursor_visual_col_walk(chars, 1, &[]), 2);
+    }
+
+    #[test]
+    fn cursor_visual_col_walk_zero_width_chars_advance_nothing() {
+        // Combining marks / ZWJ / variation selectors report width 0 and must
+        // not advance the visual column (the draw path mirrors this so the
+        // row is never clipped short by them).
+        // "e" + U+0301 (combining acute) then a wide CJK char "你" (2 cells).
+        let chars = "e\u{301}".chars().chain("\u{4F60}".chars());
+        // Cursor on the combining mark (col 1) stays at the 'e' cell.
+        assert_eq!(cursor_visual_col_walk(chars.clone(), 1, &[]), 1);
+        // Cursor on the CJK char (col 2): 'e' (1) + zero-width (0) = 1, then
+        // CJK occupies cells 1-2, so its start sits at visual col 1.
+        assert_eq!(cursor_visual_col_walk(chars, 2, &[]), 1);
+    }
+
+    #[test]
     fn tokenizer_splits_log_prefix_and_url() {
         let p = DebugPalette::default();
         let parts = tokenize_console_line(
@@ -6089,7 +6134,12 @@ fn draw_line_with_selection(
                 break;
             }
         }
-        let display_w = if *c == '\t' { TAB_WIDTH } else { 1 };
+        // Display width must match what the terminal actually advances for a
+        // character: tabs expand to `TAB_WIDTH` cells and CJK / other wide
+        // glyphs are two cells wide, but the syntax cache positions every other
+        // byte-colour by 1. Treating a wide char as 1 cell would draw the cursor
+        // (and clip the viewport) short of the CJK text's real end.
+        let display_w = char_width(*c, TAB_WIDTH);
         let char_visual_end = line_visual_pos + display_w;
         // Entirely off the left edge — advance trackers, render nothing.
         if char_visual_end <= view_left {
@@ -6102,12 +6152,26 @@ fn draw_line_with_selection(
         // viewport edge mid-tab.
         let visible_left = line_visual_pos.max(view_left);
         let visible_right = char_visual_end.min(view_left + avail);
-        if visible_right <= visible_left {
-            clipped_right = true;
-            break;
-        }
-        let visible_w = visible_right - visible_left;
-        if visual_used + visible_w > avail {
+        let visible_w = visible_right.saturating_sub(visible_left);
+        if visible_w == 0 {
+            if display_w > 0 || line_visual_pos >= view_left + avail {
+                // A positive-width char entirely past the right edge, or a
+                // zero-width char sitting at/after the pane's right edge —
+                // stop the row here. (A *visible* zero-width char — combining
+                // mark, ZWJ, variation selector — must never clip the row: it
+                // composes onto the previous cell and advances nothing.)
+                clipped_right = true;
+                break;
+            }
+            if line_visual_pos < view_left {
+                // Zero-width char entirely off the left edge: skip, don't
+                // advance (it has nothing to hang off of here anyway).
+                byte_off += c.len_utf8();
+                continue;
+            }
+            // Visible zero-width char — fall through and paint it in place;
+            // the trackers at the loop tail add 0 / no-op.
+        } else if visual_used + visible_w > avail {
             clipped_right = true;
             break;
         }
@@ -8181,10 +8245,15 @@ pub(crate) fn cursor_visual_col_walk(
         if i >= cursor_col {
             break;
         }
+        // Non-tab chars advance by their terminal display width, not 1 — CJK /
+        // wide glyphs are two cells wide. If this walk counted a wide char as 1
+        // cell it would (a) place the cursor short of the line end and (b) tell
+        // the viewport the line is narrower than it is, so a CJK-heavy line
+        // overflows the pane's right edge and its end becomes unreachable.
         if let Some(w) = hint_widths.get(i) {
             visual += *w;
         }
-        visual += if c == '\t' { TAB_WIDTH } else { 1 };
+        visual += char_width(c, TAB_WIDTH);
     }
     visual
 }


### PR DESCRIPTION
Click-to-position, cursor placement, and the horizontal viewport walk all advanced every non-tab character by 1 cell, so CJK / other wide glyphs (2 terminal cells) landed the cursor mid-glyph and clipped CJK-heavy lines short of the real end.

### Changes
- `char_width(c, tab_width)` helper next to `TAB_WIDTH` unifies the rule (tab → tab stop, wide glyphs → 2 cells, control chars → 1, zero-width → 0) across the draw walk, cursor walk, click walk, markdown concealed-mode walks, and hover-popup sizing — eliminating the divergence where the renderer laid CJK out at 2 cells while clicks/cursor still counted 1.
- The draw clip guard is now zero-width-aware: visible combining marks / ZWJ / variation selectors compose in place without truncating the rest of the row (previously a width-0 char blanked everything after it on the line).

### Tests
Regression tests for wide-char click/cursor walks and the zero-width advance case. `cargo test` / `cargo fmt` clean.